### PR TITLE
[Fix/#46] 상담 내역 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/account/service/AccountService.java
+++ b/src/main/java/com/example/humorie/account/service/AccountService.java
@@ -134,5 +134,13 @@ public class AccountService {
             throw new ErrorException(ErrorCode.NONE_EXIST_USER);
         }
     }
+
+    public String isAccountNameAvailable(String accountName) {
+        if(accountRepository.existsByAccountName(accountName)) {
+            throw new ErrorException(ErrorCode.ID_EXISTS);
+        }
+
+        return "The account name is available";
+    }
 }
 

--- a/src/main/java/com/example/humorie/account/service/AccountService.java
+++ b/src/main/java/com/example/humorie/account/service/AccountService.java
@@ -1,7 +1,7 @@
 package com.example.humorie.account.service;
 
 
-import com.example.humorie.account.config.SecurityConfig;
+import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.dto.response.TokenDto;
 import com.example.humorie.account.dto.request.JoinReq;
 import com.example.humorie.account.dto.request.LoginReq;

--- a/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
+++ b/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
@@ -42,7 +42,7 @@ public class ConsultDetailController {
     @Operation(summary = "전체 상담 내역 조회")
     public ConsultDetailPageDto getConsultDetails(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "0") int page, // 페이지 번호를 0부터 시작
             @RequestParam(defaultValue = "9") int size
     ) {
         // 페이지 번호와 크기에 대한 유효성 검사
@@ -51,8 +51,7 @@ public class ConsultDetailController {
             throw new ErrorException(ErrorCode.REQUEST_ERROR);
         }
 
-        // Pageable 객체 생성 - page는 1부터 시작하므로, 0 기반 인덱스로 변환하기 위해 1을 뺍니다.
-        Pageable pageable = PageRequest.of(page - 1, size);
+        Pageable pageable = PageRequest.of(page, size);
         return consultDetailService.findAllConsultDetail(principalDetails, pageable);
     }
 

--- a/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
+++ b/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
@@ -30,9 +30,9 @@ public class ConsultDetailController {
     private final AccountService accountService;
     private final ConsultDetailService consultDetailService;
 
-    // 가장 최근 상담 내역 조회
+    // 가장 최근에 받은 상담 조회
     @GetMapping("/latest")
-    @Operation(summary = "가장 최근에 받은 상담")
+    @Operation(summary = "가장 최근에 받은 상담 조회")
     public LatestConsultDetailResDto getLatestConsultDetail(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         return consultDetailService.getLatestConsultDetailResponse(principalDetails);
     }

--- a/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailListDto.java
+++ b/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailListDto.java
@@ -9,14 +9,16 @@ import java.time.LocalDate;
 @Getter
 public class ConsultDetailListDto {
     private final Long id;
+    private final Boolean status;
     private final String counselorName;
     private final String counselContent;
     private final String location;
     private final LocalDate counselDate;
 
     @Builder
-    public ConsultDetailListDto(Long id, String counselorName, String counselContent, String location, LocalDate counselDate) {
+    public ConsultDetailListDto(Long id, Boolean status, String counselorName, String counselContent, String location, LocalDate counselDate) {
         this.id = id;
+        this.status = status;
         this.counselorName = counselorName;
         this.counselContent = counselContent;
         this.location = location;
@@ -26,6 +28,7 @@ public class ConsultDetailListDto {
     public static ConsultDetailListDto fromEntity(ConsultDetail consultDetail) {
         return ConsultDetailListDto.builder()
                 .id(consultDetail.getId())
+                .status(consultDetail.getStatus())
                 .counselorName(consultDetail.getCounselorName())
                 .counselContent(consultDetail.getCounselContent())
                 .location(consultDetail.getLocation())

--- a/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailPageDto.java
+++ b/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailPageDto.java
@@ -14,28 +14,14 @@ public class ConsultDetailPageDto {
     private final int totalPages;
 
     public ConsultDetailPageDto(Page<ConsultDetailListDto> consultDetailPage) {
-        this.consultDetails = consultDetailPage.getContent();
-        this.pageNumber = consultDetailPage.getNumber();
-        this.pageSize = consultDetailPage.getSize();
-        this.totalElements = consultDetailPage.getTotalElements();
-        this.totalPages = consultDetailPage.getTotalPages();
-    }
-
-    public ConsultDetailPageDto(List<ConsultDetailListDto> consultDetails, int pageNumber, int pageSize, long totalElements, int totalPages) {
-        this.consultDetails = consultDetails;
-        this.pageNumber = pageNumber;
-        this.pageSize = pageSize;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
+        this.consultDetails = consultDetailPage.getContent(); // 현재 페이지에 있는 데이터 목록
+        this.pageNumber = consultDetailPage.getNumber(); // 현재 페이지 번호
+        this.pageSize = consultDetailPage.getSize(); // 한 페이지에 표시되는 항목 수
+        this.totalElements = consultDetailPage.getTotalElements(); // 전체 항목 수
+        this.totalPages = consultDetailPage.getTotalPages(); // 총 페이지 수
     }
 
     public static ConsultDetailPageDto from(Page<ConsultDetailListDto> consultDetailPage) {
-        return new ConsultDetailPageDto(
-                consultDetailPage.getContent(),
-                consultDetailPage.getNumber(),
-                consultDetailPage.getSize(),
-                consultDetailPage.getTotalElements(),
-                consultDetailPage.getTotalPages()
-        );
+        return new ConsultDetailPageDto(consultDetailPage);
     }
 }

--- a/src/main/java/com/example/humorie/consult_detail/entity/ConsultDetail.java
+++ b/src/main/java/com/example/humorie/consult_detail/entity/ConsultDetail.java
@@ -9,15 +9,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "consult_detail")
 public class ConsultDetail {
     @Id

--- a/src/main/java/com/example/humorie/consult_detail/repository/ConsultDetailRepository.java
+++ b/src/main/java/com/example/humorie/consult_detail/repository/ConsultDetailRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface ConsultDetailRepository extends JpaRepository<ConsultDetail, Long> {
-    // 가장 최근 상담 내역 조회
+    // 가장 최근에 받은 상담 조회
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")
-    Optional<ConsultDetail> findLatestConsultDetail(@Param("account") AccountDetail account);
+    List<ConsultDetail> findLatestConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
     // 상담 내역 전체 조회
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")

--- a/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
+++ b/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
@@ -53,7 +53,7 @@ public class ReviewService {
 
         counselor.setReviewCount(counselor.getReviewCount() + 1);
 
-        List<Review> reviews = reviewRepository.findAllByCounselorId(counselorId);
+        List<Review> reviews = reviewRepository.findByCounselorId(counselorId);
         double averageRating = reviews.stream()
                 .mapToDouble(Review::getRating)
                 .average()
@@ -114,7 +114,7 @@ public class ReviewService {
     }
 
     public List<ReviewRes> getReviewListByCounselor(long counselorId) {
-        List<Review> reviews = reviewRepository.findAllByCounselorId(counselorId);
+        List<Review> reviews = reviewRepository.findByCounselorId(counselorId);
 
         return reviews.stream()
                 .sorted(Comparator.comparingDouble(Review::getRating).reversed())

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -58,7 +58,8 @@ public enum ErrorCode {
 
     // consult_detail
     NONE_EXIST_CONSULT_DETAIL(false, 3006, "존재하지 않는 상담 내역입니다."),
-    CONSULT_DETAIL_NOT_COMPLETED(false, 3007, "상담 내용을 작성하고 있는 중이에요");
+    CONSULT_DETAIL_NOT_COMPLETED(false, 3007, "상담 내용을 작성하고 있는 중이에요"),
+    NO_RECENT_CONSULT_DETAIL(false, 3008, "최근 상담 내역이 없습니다.");
 
     private final boolean isSuccess;
 

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -40,9 +40,7 @@ public enum ErrorCode {
     NONE_EXIST_REVIEW(false, 2013, "존재하지 않는 리뷰입니다."),
     REVIEW_PERMISSION_DENIED(false, 2014, "본인이 작성한 리뷰만 수정, 삭제할 수 있습니다."),
     INVALID_NAME(false, 2015, "잘못된 이름 형식입니다."),
-    EXCEED_POINT(false, 2016, "포인트가 초과되었습니다."),
     EMPTY_NAME(false, 2017, "이름을 입력해주세요"),
-    EXCEED_POINT(false, 2018, "포인트가 초과되었습니다."),
     EMPTY_EMAIL(false, 2019, "이메일을 입력해주세요"),
     EMPTY_PASSWORD(false, 2020, "비밀번를 입력해주세요"),
 

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -1,5 +1,7 @@
 package com.example.humorie.global.init;
 
+import com.example.humorie.consult_detail.entity.ConsultDetail;
+import com.example.humorie.consult_detail.repository.ConsultDetailRepository;
 import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.account.repository.AccountRepository;
@@ -37,6 +39,7 @@ public class DataInitializer implements CommandLineRunner {
     private final PointRepository pointRepository;
     private final ReservationRepository reservationRepository;
     private final SecurityConfig securityConfig;
+    private final ConsultDetailRepository consultDetailRepository;
 
 
     @Override
@@ -217,6 +220,25 @@ public class DataInitializer implements CommandLineRunner {
         Reservation reservation3 = Reservation.builder().counselDate(LocalDate.of(2024,8,20)).account(accountDetail1).counselTime(LocalTime.of(12,0)).location("서울 강남구").counselor(counselor3).build();
         Reservation reservation4 = Reservation.builder().counselDate(LocalDate.of(2024,8,21)).account(accountDetail2).counselTime(LocalTime.of(12,0)).location("서울 강남구").counselor(counselor2).build();
 
+        ConsultDetail consultDetail1 = ConsultDetail.builder()
+                .status(true)
+                .account(accountDetail1)
+                .counselor(counselor1)
+                .reservation(reservation1)
+                .content("상담 내용 1")
+                .symptom("증상 1")
+                .title("상담 제목 1")
+                .build();
+
+        ConsultDetail consultDetail3 = ConsultDetail.builder()
+                .status(false)
+                .account(accountDetail1)
+                .counselor(counselor3)
+                .reservation(reservation3)
+                .content("상담 내용 3")
+                .symptom("증상 3")
+                .title("상담 제목 3")
+                .build();
 
 
         counselorRepository.saveAll(Arrays.asList(counselor1, counselor2, counselor3, counselor4, counselor5, counselor6));
@@ -229,6 +251,6 @@ public class DataInitializer implements CommandLineRunner {
         careerRepository.saveAll(Arrays.asList(career1, career2, career3, career4, career5, career6, career7, career8));
         pointRepository.saveAll(Arrays.asList(point1, point2, point3, point4, point5, point6, point7));
         reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4));
-
+        consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail3));
     }
 }

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
@@ -1,6 +1,6 @@
 package com.example.humorie.mypage.service;
 
-import com.example.humorie.account.config.SecurityConfig;
+import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.account.jwt.PrincipalDetails;
 import com.example.humorie.account.repository.AccountRepository;


### PR DESCRIPTION
- SecurityConfig 경로 account에서 global로 수정

ErrorCode.java
- 중복된 에러 코드(EXCEED POINT) 2개 제거

ReviewService.java
- findAllByCounselorId를 findByCounselorId로 수정

AccountService.java
- isAccountNameAvailable(아이디 중복체크 관련) 복구

가장 최근에 받은 상담 조회 API
- pageable 이용해서 가장 최근에 받은 상담 내역 하나만 반환하도록 수정

상담 내역 전체 조회
- pageable을 이용해서 페이지네이션 구현

특정 상담 내역 조회