### PR TITLE
[Feat/#48] 공지사항 API 구현

### DIFF
--- a/src/main/java/com/example/humorie/account/service/AccountService.java
+++ b/src/main/java/com/example/humorie/account/service/AccountService.java
@@ -134,5 +134,13 @@ public class AccountService {
             throw new ErrorException(ErrorCode.NONE_EXIST_USER);
         }
     }
+
+    public String isAccountNameAvailable(String accountName) {
+        if(accountRepository.existsByAccountName(accountName)) {
+            throw new ErrorException(ErrorCode.ID_EXISTS);
+        }
+
+        return "The account name is available";
+    }
 }
 

--- a/src/main/java/com/example/humorie/account/service/AccountService.java
+++ b/src/main/java/com/example/humorie/account/service/AccountService.java
@@ -1,7 +1,7 @@
 package com.example.humorie.account.service;
 
 
-import com.example.humorie.account.config.SecurityConfig;
+import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.dto.response.TokenDto;
 import com.example.humorie.account.dto.request.JoinReq;
 import com.example.humorie.account.dto.request.LoginReq;

--- a/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
+++ b/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
@@ -42,7 +42,7 @@ public class ConsultDetailController {
     @Operation(summary = "전체 상담 내역 조회")
     public ConsultDetailPageDto getConsultDetails(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "0") int page, // 페이지 번호를 0부터 시작
             @RequestParam(defaultValue = "9") int size
     ) {
         // 페이지 번호와 크기에 대한 유효성 검사
@@ -51,8 +51,7 @@ public class ConsultDetailController {
             throw new ErrorException(ErrorCode.REQUEST_ERROR);
         }
 
-        // Pageable 객체 생성 - page는 1부터 시작하므로, 0 기반 인덱스로 변환하기 위해 1을 뺍니다.
-        Pageable pageable = PageRequest.of(page - 1, size);
+        Pageable pageable = PageRequest.of(page, size);
         return consultDetailService.findAllConsultDetail(principalDetails, pageable);
     }
 

--- a/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
+++ b/src/main/java/com/example/humorie/consult_detail/controller/ConsultDetailController.java
@@ -30,9 +30,9 @@ public class ConsultDetailController {
     private final AccountService accountService;
     private final ConsultDetailService consultDetailService;
 
-    // 가장 최근 상담 내역 조회
+    // 가장 최근에 받은 상담 조회
     @GetMapping("/latest")
-    @Operation(summary = "가장 최근에 받은 상담")
+    @Operation(summary = "가장 최근에 받은 상담 조회")
     public LatestConsultDetailResDto getLatestConsultDetail(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         return consultDetailService.getLatestConsultDetailResponse(principalDetails);
     }

--- a/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailListDto.java
+++ b/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailListDto.java
@@ -9,14 +9,16 @@ import java.time.LocalDate;
 @Getter
 public class ConsultDetailListDto {
     private final Long id;
+    private final Boolean status;
     private final String counselorName;
     private final String counselContent;
     private final String location;
     private final LocalDate counselDate;
 
     @Builder
-    public ConsultDetailListDto(Long id, String counselorName, String counselContent, String location, LocalDate counselDate) {
+    public ConsultDetailListDto(Long id, Boolean status, String counselorName, String counselContent, String location, LocalDate counselDate) {
         this.id = id;
+        this.status = status;
         this.counselorName = counselorName;
         this.counselContent = counselContent;
         this.location = location;
@@ -26,6 +28,7 @@ public class ConsultDetailListDto {
     public static ConsultDetailListDto fromEntity(ConsultDetail consultDetail) {
         return ConsultDetailListDto.builder()
                 .id(consultDetail.getId())
+                .status(consultDetail.getStatus())
                 .counselorName(consultDetail.getCounselorName())
                 .counselContent(consultDetail.getCounselContent())
                 .location(consultDetail.getLocation())

--- a/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailPageDto.java
+++ b/src/main/java/com/example/humorie/consult_detail/dto/response/ConsultDetailPageDto.java
@@ -14,28 +14,14 @@ public class ConsultDetailPageDto {
     private final int totalPages;
 
     public ConsultDetailPageDto(Page<ConsultDetailListDto> consultDetailPage) {
-        this.consultDetails = consultDetailPage.getContent();
-        this.pageNumber = consultDetailPage.getNumber();
-        this.pageSize = consultDetailPage.getSize();
-        this.totalElements = consultDetailPage.getTotalElements();
-        this.totalPages = consultDetailPage.getTotalPages();
-    }
-
-    public ConsultDetailPageDto(List<ConsultDetailListDto> consultDetails, int pageNumber, int pageSize, long totalElements, int totalPages) {
-        this.consultDetails = consultDetails;
-        this.pageNumber = pageNumber;
-        this.pageSize = pageSize;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
+        this.consultDetails = consultDetailPage.getContent(); // 현재 페이지에 있는 데이터 목록
+        this.pageNumber = consultDetailPage.getNumber(); // 현재 페이지 번호
+        this.pageSize = consultDetailPage.getSize(); // 한 페이지에 표시되는 항목 수
+        this.totalElements = consultDetailPage.getTotalElements(); // 전체 항목 수
+        this.totalPages = consultDetailPage.getTotalPages(); // 총 페이지 수
     }
 
     public static ConsultDetailPageDto from(Page<ConsultDetailListDto> consultDetailPage) {
-        return new ConsultDetailPageDto(
-                consultDetailPage.getContent(),
-                consultDetailPage.getNumber(),
-                consultDetailPage.getSize(),
-                consultDetailPage.getTotalElements(),
-                consultDetailPage.getTotalPages()
-        );
+        return new ConsultDetailPageDto(consultDetailPage);
     }
 }

--- a/src/main/java/com/example/humorie/consult_detail/entity/ConsultDetail.java
+++ b/src/main/java/com/example/humorie/consult_detail/entity/ConsultDetail.java
@@ -9,15 +9,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "consult_detail")
 public class ConsultDetail {
     @Id

--- a/src/main/java/com/example/humorie/consult_detail/repository/ConsultDetailRepository.java
+++ b/src/main/java/com/example/humorie/consult_detail/repository/ConsultDetailRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface ConsultDetailRepository extends JpaRepository<ConsultDetail, Long> {
-    // 가장 최근 상담 내역 조회
+    // 가장 최근에 받은 상담 조회
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")
-    Optional<ConsultDetail> findLatestConsultDetail(@Param("account") AccountDetail account);
+    List<ConsultDetail> findLatestConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
     // 상담 내역 전체 조회
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")

--- a/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
+++ b/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
@@ -53,7 +53,7 @@ public class ReviewService {
 
         counselor.setReviewCount(counselor.getReviewCount() + 1);
 
-        List<Review> reviews = reviewRepository.findAllByCounselorId(counselorId);
+        List<Review> reviews = reviewRepository.findByCounselorId(counselorId);
         double averageRating = reviews.stream()
                 .mapToDouble(Review::getRating)
                 .average()
@@ -114,7 +114,7 @@ public class ReviewService {
     }
 
     public List<ReviewRes> getReviewListByCounselor(long counselorId) {
-        List<Review> reviews = reviewRepository.findAllByCounselorId(counselorId);
+        List<Review> reviews = reviewRepository.findByCounselorId(counselorId);
 
         return reviews.stream()
                 .sorted(Comparator.comparingDouble(Review::getRating).reversed())

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -59,7 +59,15 @@ public enum ErrorCode {
     // consult_detail
     NONE_EXIST_CONSULT_DETAIL(false, 3006, "존재하지 않는 상담 내역입니다."),
     CONSULT_DETAIL_NOT_COMPLETED(false, 3007, "상담 내용을 작성하고 있는 중이에요"),
-    NO_RECENT_CONSULT_DETAIL(false, 3008, "최근 상담 내역이 없습니다.");
+    NO_RECENT_CONSULT_DETAIL(false, 3008, "최근 상담 내역이 없습니다."),
+
+    // notice
+    NONE_EXIST_NOTICE(false, 3009,"존재하지 않는 공지사항입니다."),
+    NO_CONTENT(false, 3010,"표시할 콘텐츠가 없습니다."),
+    INVALID_PAGE_NUMBER(false, 3011,"페이지 번호가 전체 페이지 수를 초과했습니다."),
+    NEGATIVE_PAGE_NUMBER(false, 3012,"페이지 번호는 0 이상이어야 합니다."),
+    INVALID_PAGE_SIZE(false, 3013,"페이지 크기가 최대 허용 값을 초과했습니다."),
+    NEGATIVE_PAGE_SIZE(false, 3014,"페이지 크기는 0 이상이어야 합니다.");;
 
     private final boolean isSuccess;
 

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -67,7 +67,8 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(false, 3011,"페이지 번호가 전체 페이지 수를 초과했습니다."),
     NEGATIVE_PAGE_NUMBER(false, 3012,"페이지 번호는 0 이상이어야 합니다."),
     INVALID_PAGE_SIZE(false, 3013,"페이지 크기가 최대 허용 값을 초과했습니다."),
-    NEGATIVE_PAGE_SIZE(false, 3014,"페이지 크기는 0 이상이어야 합니다.");;
+    NEGATIVE_PAGE_SIZE(false, 3014,"페이지 크기는 0 이상이어야 합니다."),
+    NO_SEARCH_RESULTS(false, 3015,"검색 결과가 없습니다.");
 
     private final boolean isSuccess;
 

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -58,7 +58,8 @@ public enum ErrorCode {
 
     // consult_detail
     NONE_EXIST_CONSULT_DETAIL(false, 3006, "존재하지 않는 상담 내역입니다."),
-    CONSULT_DETAIL_NOT_COMPLETED(false, 3007, "상담 내용을 작성하고 있는 중이에요");
+    CONSULT_DETAIL_NOT_COMPLETED(false, 3007, "상담 내용을 작성하고 있는 중이에요"),
+    NO_RECENT_CONSULT_DETAIL(false, 3008, "최근 상담 내역이 없습니다.");
 
     private final boolean isSuccess;
 

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -40,9 +40,7 @@ public enum ErrorCode {
     NONE_EXIST_REVIEW(false, 2013, "존재하지 않는 리뷰입니다."),
     REVIEW_PERMISSION_DENIED(false, 2014, "본인이 작성한 리뷰만 수정, 삭제할 수 있습니다."),
     INVALID_NAME(false, 2015, "잘못된 이름 형식입니다."),
-    EXCEED_POINT(false, 2016, "포인트가 초과되었습니다."),
     EMPTY_NAME(false, 2017, "이름을 입력해주세요"),
-    EXCEED_POINT(false, 2018, "포인트가 초과되었습니다."),
     EMPTY_EMAIL(false, 2019, "이메일을 입력해주세요"),
     EMPTY_PASSWORD(false, 2020, "비밀번를 입력해주세요"),
 

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -1,5 +1,7 @@
 package com.example.humorie.global.init;
 
+import com.example.humorie.consult_detail.entity.ConsultDetail;
+import com.example.humorie.consult_detail.repository.ConsultDetailRepository;
 import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.account.repository.AccountRepository;
@@ -37,6 +39,7 @@ public class DataInitializer implements CommandLineRunner {
     private final PointRepository pointRepository;
     private final ReservationRepository reservationRepository;
     private final SecurityConfig securityConfig;
+    private final ConsultDetailRepository consultDetailRepository;
 
 
     @Override
@@ -217,6 +220,25 @@ public class DataInitializer implements CommandLineRunner {
         Reservation reservation3 = Reservation.builder().counselDate(LocalDate.of(2024,8,20)).account(accountDetail1).counselTime(LocalTime.of(12,0)).location("서울 강남구").counselor(counselor3).build();
         Reservation reservation4 = Reservation.builder().counselDate(LocalDate.of(2024,8,21)).account(accountDetail2).counselTime(LocalTime.of(12,0)).location("서울 강남구").counselor(counselor2).build();
 
+        ConsultDetail consultDetail1 = ConsultDetail.builder()
+                .status(true)
+                .account(accountDetail1)
+                .counselor(counselor1)
+                .reservation(reservation1)
+                .content("상담 내용 1")
+                .symptom("증상 1")
+                .title("상담 제목 1")
+                .build();
+
+        ConsultDetail consultDetail3 = ConsultDetail.builder()
+                .status(false)
+                .account(accountDetail1)
+                .counselor(counselor3)
+                .reservation(reservation3)
+                .content("상담 내용 3")
+                .symptom("증상 3")
+                .title("상담 제목 3")
+                .build();
 
 
         counselorRepository.saveAll(Arrays.asList(counselor1, counselor2, counselor3, counselor4, counselor5, counselor6));
@@ -229,6 +251,6 @@ public class DataInitializer implements CommandLineRunner {
         careerRepository.saveAll(Arrays.asList(career1, career2, career3, career4, career5, career6, career7, career8));
         pointRepository.saveAll(Arrays.asList(point1, point2, point3, point4, point5, point6, point7));
         reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4));
-
+        consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail3));
     }
 }

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -11,6 +11,8 @@ import com.example.humorie.consultant.review.entity.Review;
 import com.example.humorie.consultant.review.repository.ReviewRepository;
 import com.example.humorie.mypage.entity.Point;
 import com.example.humorie.mypage.repository.PointRepository;
+import com.example.humorie.notice.entity.Notice;
+import com.example.humorie.notice.repository.NoticeRepository;
 import com.example.humorie.reservation.entity.Reservation;
 import com.example.humorie.reservation.repository.ReservationRepository;
 import jakarta.transaction.Transactional;
@@ -21,7 +23,9 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -40,7 +44,7 @@ public class DataInitializer implements CommandLineRunner {
     private final ReservationRepository reservationRepository;
     private final SecurityConfig securityConfig;
     private final ConsultDetailRepository consultDetailRepository;
-
+    private final NoticeRepository noticeRepository;
 
     @Override
     @Transactional
@@ -240,6 +244,26 @@ public class DataInitializer implements CommandLineRunner {
                 .title("상담 제목 3")
                 .build();
 
+        List<Notice> notices = new ArrayList<>();
+        int importanceCount = 0;
+
+        for (int i = 1; i <= 10; i++) {
+            boolean isImportant = importanceCount < 3;  // 처음 3개만 중요
+            if (isImportant) {
+                importanceCount++;
+            }
+
+            Notice notice = Notice.builder()
+                    .title("공지사항 제목 " + i)
+                    .content("이것은 공지사항 내용 " + i + "입니다.")
+                    .importance(isImportant)
+                    .createdDate(LocalDate.now().minusDays(i / 2))  // 두 개씩 같은 날짜로 설정
+                    .createdTime(LocalTime.of(9, 0).plusHours(i))   // 시간을 다르게 설정
+                    .viewCount(i * 10)
+                    .author("작성자 " + i)
+                    .build();
+            notices.add(notice);
+        }
 
         counselorRepository.saveAll(Arrays.asList(counselor1, counselor2, counselor3, counselor4, counselor5, counselor6));
         methodRepository.saveAll(Arrays.asList(method1, method2, method3, method4, method5, method6, method7, method8));
@@ -252,5 +276,6 @@ public class DataInitializer implements CommandLineRunner {
         pointRepository.saveAll(Arrays.asList(point1, point2, point3, point4, point5, point6, point7));
         reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4));
         consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail3));
+        noticeRepository.saveAll(notices);
     }
 }

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
@@ -1,6 +1,6 @@
 package com.example.humorie.mypage.service;
 
-import com.example.humorie.account.config.SecurityConfig;
+import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.account.jwt.PrincipalDetails;
 import com.example.humorie.account.repository.AccountRepository;

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -3,10 +3,12 @@ package com.example.humorie.notice.controller;
 import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
 import com.example.humorie.notice.dto.GetAllNoticeDto;
+import com.example.humorie.notice.dto.NoticeDetailDto;
 import com.example.humorie.notice.dto.NoticePageDto;
 import com.example.humorie.notice.entity.Notice;
 import com.example.humorie.notice.service.NoticeService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 @RestController
@@ -73,5 +76,11 @@ public class NoticeController {
         }
 
         return noticeService.searchNotices(keyword, pageable);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "특정 공지사항 조회")
+    public NoticeDetailDto getNoticeById(@PathVariable Long id) {
+        return noticeService.getNoticeById(id);
     }
 }

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -4,6 +4,7 @@ import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
 import com.example.humorie.notice.dto.GetAllNoticeDto;
 import com.example.humorie.notice.dto.NoticeDetailDto;
+import com.example.humorie.notice.dto.NoticeDetailWithNavigationDto;
 import com.example.humorie.notice.dto.NoticePageDto;
 import com.example.humorie.notice.entity.Notice;
 import com.example.humorie.notice.service.NoticeService;
@@ -79,8 +80,8 @@ public class NoticeController {
     }
 
     @GetMapping("/{id}")
-    @Operation(summary = "특정 공지사항 조회")
-    public NoticeDetailDto getNoticeById(@PathVariable Long id) {
-        return noticeService.getNoticeById(id);
+    @Operation(summary = "특정 공지사항 및 이전/다음 공지사항 조회")
+    public NoticeDetailWithNavigationDto getNoticeWithNavigation(@PathVariable Long id) {
+        return noticeService.getNoticeWithNavigation(id);
     }
 }

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notice")
@@ -45,5 +44,34 @@ public class NoticeController {
 
         Pageable pageable = PageRequest.of(page, size);
         return noticeService.getAllNotices(pageable);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "공지사항 검색")
+    public NoticePageDto searchNotices(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "9") int size
+    ) {
+        // 페이지 번호에 대한 유효성 검사
+        if (page < 0) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_NUMBER);
+        }
+
+        // 페이지 크기에 대한 유효성 검사
+        if (size < 1) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
+        } else if (size > 9) {
+            throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 키워드가 없는 경우 전체 공지사항 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return noticeService.getAllNotices(pageable);
+        }
+
+        return noticeService.searchNotices(keyword, pageable);
     }
 }

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -1,0 +1,49 @@
+package com.example.humorie.notice.controller;
+
+import com.example.humorie.global.exception.ErrorCode;
+import com.example.humorie.global.exception.ErrorException;
+import com.example.humorie.notice.dto.GetAllNoticeDto;
+import com.example.humorie.notice.dto.NoticePageDto;
+import com.example.humorie.notice.entity.Notice;
+import com.example.humorie.notice.service.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/get")
+    @Operation(summary = "공지사항 전체 조회")
+    public NoticePageDto getAllNotices(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "9") int size
+    ) {
+        // 페이지 번호에 대한 유효성 검사
+        if (page < 0) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_NUMBER);
+        }
+
+        // 페이지 크기에 대한 유효성 검사
+        if (size < 1) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
+        } else if (size > 9) {
+            throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+        return noticeService.getAllNotices(pageable);
+    }
+}

--- a/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
@@ -1,0 +1,28 @@
+package com.example.humorie.notice.dto;
+
+import com.example.humorie.notice.entity.Notice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class GetAllNoticeDto {
+    private Long id;
+    private boolean importance;
+    private String title;
+    private LocalDate createdDate;
+    private int viewCount;
+
+    // Notice 엔티티를 GetAllNoticeDto로 변환하는 메서드
+    public static GetAllNoticeDto fromEntity(Notice notice) {
+        return GetAllNoticeDto.builder()
+                .id(notice.getId())
+                .importance(notice.isImportance())
+                .title(notice.getTitle())
+                .createdDate(notice.getCreatedDate())
+                .viewCount(notice.getViewCount())
+                .build();
+    }
+}

--- a/src/main/java/com/example/humorie/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/NoticeDetailDto.java
@@ -1,0 +1,41 @@
+package com.example.humorie.notice.dto;
+
+import com.example.humorie.notice.entity.Notice;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeDetailDto {
+    private Long id;
+    private String author;         // 작성자
+    private int viewCount;         // 조회수
+    private LocalDate createdDate; // 작성일
+    private LocalTime createdTime; // 작성 시간
+    private String title;          // 제목
+    private String content;        // 내용
+    private boolean importance;    // 중요 여부
+
+    // Notice 엔티티를 DTO로 변환하는 메서드
+    public static NoticeDetailDto fromEntity(Notice notice) {
+        return NoticeDetailDto.builder()
+                .id(notice.getId())
+                .author(notice.getAuthor())
+                .viewCount(notice.getViewCount())
+                .createdDate(notice.getCreatedDate())
+                .createdTime(notice.getCreatedTime())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .importance(notice.isImportance())
+                .build();
+    }
+}

--- a/src/main/java/com/example/humorie/notice/dto/NoticeDetailWithNavigationDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/NoticeDetailWithNavigationDto.java
@@ -1,0 +1,14 @@
+package com.example.humorie.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class NoticeDetailWithNavigationDto {
+    private NoticeDetailDto currentNotice;  // 현재 공지사항의 세부 정보
+    private NoticeSummaryDto previousNotice; // 이전 공지사항의 요약 정보
+    private NoticeSummaryDto nextNotice;     // 다음 공지사항의 요약 정보
+}

--- a/src/main/java/com/example/humorie/notice/dto/NoticePageDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/NoticePageDto.java
@@ -1,0 +1,31 @@
+package com.example.humorie.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class NoticePageDto {
+    private List<GetAllNoticeDto> notices;  // 현재 페이지에 있는 DTO 목록
+    private int pageNumber;                 // 현재 페이지 번호
+    private int pageSize;                   // 한 페이지에 표시되는 항목 수
+    private long totalElements;             // 전체 항목 수
+    private int totalPages;                 // 총 페이지 수
+
+    public NoticePageDto(Page<GetAllNoticeDto> noticePage) {
+        this.notices = noticePage.getContent(); // 현재 페이지에 있는 데이터 목록
+        this.pageNumber = noticePage.getNumber(); // 현재 페이지 번호
+        this.pageSize = noticePage.getSize(); // 한 페이지에 표시되는 항목 수
+        this.totalElements = noticePage.getTotalElements(); // 전체 항목 수
+        this.totalPages = noticePage.getTotalPages(); // 총 페이지 수
+    }
+
+    public static NoticePageDto from(Page<GetAllNoticeDto> noticePage) {
+        return new NoticePageDto(noticePage);
+    }
+}

--- a/src/main/java/com/example/humorie/notice/dto/NoticeSummaryDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/NoticeSummaryDto.java
@@ -1,0 +1,15 @@
+package com.example.humorie.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeSummaryDto {
+    private Long id;           // 공지사항 ID
+    private String title;      // 공지사항 제목
+}

--- a/src/main/java/com/example/humorie/notice/entity/Notice.java
+++ b/src/main/java/com/example/humorie/notice/entity/Notice.java
@@ -1,0 +1,43 @@
+package com.example.humorie.notice.entity;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_date")
+    private LocalDate createdDate;
+
+    @Column(name = "created_time")
+    private LocalTime createdTime;
+
+    @Column(name = "view_count")
+    private int viewCount;
+
+    private boolean importance;
+
+    private String author;
+}

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -1,0 +1,12 @@
+package com.example.humorie.notice.repository;
+
+import com.example.humorie.notice.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    @Query("SELECT n FROM Notice n ORDER BY n.importance DESC, n.createdDate DESC, n.createdTime DESC")
+    Page<Notice> findImportantAndRecentNotices(Pageable pageable);
+}

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -6,7 +6,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    // 공지사항 전체 조회
     @Query("SELECT n FROM Notice n ORDER BY n.importance DESC, n.createdDate DESC, n.createdTime DESC")
     Page<Notice> findImportantAndRecentNotices(Pageable pageable);
+
+    // 중요 공지사항 조회 ( 중요도에 관계없이 출력 )
+    @Query("SELECT n FROM Notice n WHERE n.importance = true ORDER BY n.createdDate DESC, n.createdTime DESC")
+    List<Notice> findImportantNotices(Pageable pageable);
+
+    // 제목 또는 내용에 검색어가 포함된 공지사항을 검색
+    Page<Notice> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
 }

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -9,14 +9,17 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    // 공지사항 전체 조회
+    // 공지사항 전체 조회(중요도, 날짜, 시간)
     @Query("SELECT n FROM Notice n ORDER BY n.importance DESC, n.createdDate DESC, n.createdTime DESC")
     Page<Notice> findImportantAndRecentNotices(Pageable pageable);
 
-    // 중요 공지사항 조회 ( 중요도에 관계없이 출력 )
+    // 중요 공지사항 조회
     @Query("SELECT n FROM Notice n WHERE n.importance = true ORDER BY n.createdDate DESC, n.createdTime DESC")
     List<Notice> findImportantNotices(Pageable pageable);
 
     // 제목 또는 내용에 검색어가 포함된 공지사항을 검색
     Page<Notice> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
+
+    // 공지사항을 날짜와 시간 순으로 내림차순 정렬하여 전체 목록 반환
+    List<Notice> findAllByOrderByCreatedDateDescCreatedTimeDesc();
 }

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -8,8 +8,15 @@ import com.example.humorie.notice.entity.Notice;
 import com.example.humorie.notice.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +38,54 @@ public class NoticeService {
 
         // 엔티티를 DTO로 변환하여 NoticePageDto로 반환
         Page<GetAllNoticeDto> dtoPage = noticePage.map(GetAllNoticeDto::fromEntity);
+        return NoticePageDto.from(dtoPage);
+    }
+
+    public NoticePageDto searchNotices(String keyword, Pageable pageable) {
+        // 중요 공지사항 먼저 가져오기
+        List<Notice> importantNotices = noticeRepository.findImportantNotices(pageable);
+
+        // 검색 결과 가져오기
+        Page<Notice> searchResults = noticeRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+
+        // 검색 결과가 비어 있을 경우 예외 처리
+        if (importantNotices.isEmpty() && searchResults.isEmpty()) {
+            throw new ErrorException(ErrorCode.NO_SEARCH_RESULTS);
+        }
+
+        // 중요 공지사항과 검색 결과를 병합하고 중복 제거
+        Set<Notice> distinctResults = new LinkedHashSet<>();
+        distinctResults.addAll(importantNotices);
+        distinctResults.addAll(searchResults.getContent());
+
+        // 병합된 결과를 날짜 및 시간 순으로 정렬
+        List<Notice> sortedResults = new ArrayList<>(distinctResults);
+        sortedResults.sort((n1, n2) -> {
+            // 두 공지사항의 createdDate(생성일자)가 동일한 경우, createdTime(생성시간)을 비교
+            if (n1.getCreatedDate().isEqual(n2.getCreatedDate())) {
+                return n2.getCreatedTime().compareTo(n1.getCreatedTime());
+            }
+            // 날짜가 최신일수록 리스트의 앞쪽에 위치
+            return n2.getCreatedDate().compareTo(n1.getCreatedDate());
+        });
+
+        // 병합된 결과를 DTO로 변환
+        List<GetAllNoticeDto> dtoList = new ArrayList<>();
+        for (Notice notice : sortedResults) {
+            dtoList.add(GetAllNoticeDto.fromEntity(notice));
+        }
+        // 병합된 결과를 페이지네이션
+        // 페이지네이션을 위해 시작점(start)과 끝점(end) 인덱스를 계산
+        int start = Math.min((int) pageable.getOffset(), dtoList.size());
+        int end = Math.min((start + pageable.getPageSize()), dtoList.size());
+
+        // 페이지 번호가 전체 페이지 수를 초과하는 경우 예외 처리
+        if (pageable.getPageNumber() >= Math.ceil((double) dtoList.size() / pageable.getPageSize())) {
+            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+        }
+
+        Page<GetAllNoticeDto> dtoPage = new PageImpl<>(dtoList.subList(start, end), pageable, dtoList.size());
+
         return NoticePageDto.from(dtoPage);
     }
 }

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -1,0 +1,36 @@
+package com.example.humorie.notice.service;
+
+import com.example.humorie.global.exception.ErrorCode;
+import com.example.humorie.global.exception.ErrorException;
+import com.example.humorie.notice.dto.GetAllNoticeDto;
+import com.example.humorie.notice.dto.NoticePageDto;
+import com.example.humorie.notice.entity.Notice;
+import com.example.humorie.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    public NoticePageDto getAllNotices(Pageable pageable) {
+        Page<Notice> noticePage = noticeRepository.findImportantAndRecentNotices(pageable);
+
+        // 페이지 번호가 전체 페이지 수를 초과하는 경우
+        if (pageable.getPageNumber() >= noticePage.getTotalPages()) {
+            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+        }
+
+        // 페이지가 비어 있는지 확인
+        if (noticePage.isEmpty()) {
+            throw new ErrorException(ErrorCode.NO_CONTENT);
+        }
+
+        // 엔티티를 DTO로 변환하여 NoticePageDto로 반환
+        Page<GetAllNoticeDto> dtoPage = noticePage.map(GetAllNoticeDto::fromEntity);
+        return NoticePageDto.from(dtoPage);
+    }
+}

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -3,6 +3,7 @@ package com.example.humorie.notice.service;
 import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
 import com.example.humorie.notice.dto.GetAllNoticeDto;
+import com.example.humorie.notice.dto.NoticeDetailDto;
 import com.example.humorie.notice.dto.NoticePageDto;
 import com.example.humorie.notice.entity.Notice;
 import com.example.humorie.notice.repository.NoticeRepository;
@@ -87,5 +88,16 @@ public class NoticeService {
         Page<GetAllNoticeDto> dtoPage = new PageImpl<>(dtoList.subList(start, end), pageable, dtoList.size());
 
         return NoticePageDto.from(dtoPage);
+    }
+
+    public NoticeDetailDto getNoticeById(Long id) {
+        Notice notice = noticeRepository.findById(id)
+                .orElseThrow(() -> new ErrorException(ErrorCode.NONE_EXIST_NOTICE));
+
+        // 조회수 1 증가
+        notice.setViewCount(notice.getViewCount() + 1);
+        noticeRepository.save(notice); // 변경된 조회수를 데이터베이스에 저장
+
+        return NoticeDetailDto.fromEntity(notice);
     }
 }


### PR DESCRIPTION
API
- 공지사항 전체 조회 기능 구현
- 키워드로 공지사항 검색하는 기능 구현
- 특정 공지사항 조회 및 이전/다음 공지사항 네비게이션 기능 구현

- 공지사항 관련 에러 코드 추가
- 공지사항 더미 데이터 추가

+) 피그마에는 게시글에 사진이 첨부 되어있는데 아직 서버가 없어서 생략했습니다.
+) 피그마에는 글쓰기 버튼이 있는데 아직 마스터 계정 추가가 확정되지 않아서 그 부분도 역시 생략했습니다.