### PR TITLE
[#76/Fix] 특정 상담 내역 조회 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/consultant/consult_detail/controller/ConsultDetailController.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/controller/ConsultDetailController.java
@@ -51,11 +51,11 @@ public class ConsultDetailController {
         return consultDetailService.findAllConsultDetail(principalDetails, page, size);
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{consultDetailId}")
     @Operation(summary = "특정 상담 내역 조회")
     public Map<String, Object> getSpecificConsultDetail(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @PathVariable Long id
+            @PathVariable Long consultDetailId
     ) {
         // 사용자 아이디를 가져옴
         String accountName = principalDetails.getAccountDetail().getAccountName();
@@ -65,7 +65,7 @@ public class ConsultDetailController {
         String maskedAccountName = maskAccountName(accountName);
 
         // 상담 내역 DTO를 가져옴
-        SpecificConsultDetailDto consultDetail = consultDetailService.getSpecificConsultDetail(id);
+        SpecificConsultDetailDto consultDetail = consultDetailService.getSpecificConsultDetail(consultDetailId);
 
         // 응답 데이터 구성
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
@@ -10,6 +10,7 @@ import java.time.LocalTime;
 @Getter
 public class SpecificConsultDetailDto {
     private final Long id;
+    private final Long counselorId;
     private final String counselorName;
     private final String content;
     private final Boolean status;
@@ -20,8 +21,9 @@ public class SpecificConsultDetailDto {
     private final String location;
 
     @Builder
-    public SpecificConsultDetailDto(Long id, String counselorName, String content, Boolean status, String symptom, String title, LocalDate counselDate, LocalTime counselTime, String location) {  // Boolean 타입으로 설정
+    public SpecificConsultDetailDto(Long id, Long counselorId, String counselorName, String content, Boolean status, String symptom, String title, LocalDate counselDate, LocalTime counselTime, String location) {  // Boolean 타입으로 설정
         this.id = id;
+        this.counselorId = counselorId;;
         this.counselorName = counselorName;
         this.content = content;
         this.status = status;
@@ -32,9 +34,11 @@ public class SpecificConsultDetailDto {
         this.location = location;
     }
 
+    // ConsultDetail 엔티티에서 DTO로 변환하는 메서드
     public static SpecificConsultDetailDto fromEntity(ConsultDetail consultDetail) {
         return SpecificConsultDetailDto.builder()
                 .id(consultDetail.getId())
+                .counselorId(consultDetail.getCounselor().getId())
                 .counselorName(consultDetail.getCounselor().getName())
                 .content(consultDetail.getContent())
                 .status(consultDetail.getStatus())

--- a/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
@@ -14,13 +14,12 @@ import java.util.List;
 @Repository
 public interface ConsultDetailRepository extends JpaRepository<ConsultDetail, Long> {
     // 가장 최근에 받은 상담 조회
-    @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")
+    @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC, c.reservation.counselTime DESC")
     List<ConsultDetail> findLatestConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
     // 상담 내역 전체 조회
-    @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC")
+    @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC, c.reservation.counselTime DESC")
     Page<ConsultDetail> findAllConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
-    // 예약 ID를 기준으로 상담 내역 삭제
     void deleteByAccount_Id(Long accountId);
 }


### PR DESCRIPTION
** 특정 상담 내역 조회 API
- 프론트앤드 요청으로 상담사 id 필드 추가
- 유진님의 피드백을 반영해서 path parameter를 id에서 consultDetailId로 변경

** 가장 최근에 받은 상담 조회 API에서 조회한 값과 전체 상담 내역 조회 API에서 조회한 제일 첫 번째 값이 계속 달랐는데 원인을 파악하지 못했습니다. 현재 consult_detail 테이블과 reservation 테이블의 데이터를 보면, consult_detail 테이블에서 reservation_id가 3인 데이터가 여러 개 존재합니다. 이는 동일한 reservation에 여러 상담 내역이 연결되어있음을 의미합니다. 따라서 쿼리에서 reservation_id를 기준으로 정렬하는 것만으로는 정확한 시간 순서대로 정렬되지 않은 것 같습니다. 