### PR TITLE
[Fix/#78] 마이페이지 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
@@ -43,6 +43,8 @@ public class ConsultDetail {
     private String symptom;
     private String content;
 
+    private boolean deleted = false;  // 소프트 삭제 여부를 나타내는 필드
+
     public void setStatus(Boolean status) { this.status = status; }
 
     public String getContent()  { return content; }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
@@ -3,6 +3,7 @@ package com.example.humorie.consultant.consult_detail.repository;
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.account.entity.AccountDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.Page;
@@ -21,5 +22,17 @@ public interface ConsultDetailRepository extends JpaRepository<ConsultDetail, Lo
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC, c.reservation.counselTime DESC")
     Page<ConsultDetail> findAllConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
-    void deleteByAccount_Id(Long accountId);
+     void deleteByAccount_Id(Long accountId);
+
+    // accountId로 ConsultDetail 조회
+    List<ConsultDetail> findByAccountId(Long accountId);
+
+    @Modifying
+    @Query("UPDATE ConsultDetail c SET c.deleted = true WHERE c.account.id = :accountId")
+    void softDeleteByAccountId(Long accountId);
+
+    @Modifying
+    @Query("UPDATE ConsultDetail c SET c.account = NULL WHERE c.account.id = :accountId")
+    void detachAccountFromConsultDetail(@Param("accountId") Long accountId);
+
 }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -11,12 +11,14 @@ import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.consultant.consult_detail.repository.ConsultDetailRepository;
 import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
 
 import java.util.List;
 
@@ -116,5 +118,18 @@ public class ConsultDetailService {
         }
 
         return SpecificConsultDetailDto.fromEntity(consultDetail);
+    }
+
+    @Transactional
+    public void softDeleteConsultDetailsByAccountId(Long accountId) {
+        List<ConsultDetail> consultDetails = consultDetailRepository.findByAccountId(accountId);
+        for (ConsultDetail consultDetail : consultDetails) {
+            consultDetail.setDeleted(true); // 소프트 삭제 처리
+            consultDetailRepository.save(consultDetail);
+        }
+    }
+    @Transactional
+    public void detachAccountFromConsultDetail(Long accountId) {
+        consultDetailRepository.detachAccountFromConsultDetail(accountId);
     }
 }

--- a/src/main/java/com/example/humorie/consultant/review/repository/TagRepository.java
+++ b/src/main/java/com/example/humorie/consultant/review/repository/TagRepository.java
@@ -3,6 +3,9 @@ package com.example.humorie.consultant.review.repository;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.consultant.review.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,5 +23,9 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByTagNameAndAccount(String tagName, AccountDetail account);
 
     int countByAccount(AccountDetail account);
+
+    @Modifying
+    @Query("UPDATE Tag t SET t.account = NULL WHERE t.account.id = :accountId")
+    void detachAccountFromTag(@Param("accountId") Long accountId);
 
 }

--- a/src/main/java/com/example/humorie/consultant/review/service/TagService.java
+++ b/src/main/java/com/example/humorie/consultant/review/service/TagService.java
@@ -78,4 +78,8 @@ public class TagService {
         return "Deletion Success";
     }
 
+    @Transactional
+    public void detachAccountFromTag(Long accountId) {
+        tagRepository.detachAccountFromTag(accountId);
+    }
 }

--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -49,7 +49,9 @@ public enum ErrorCode {
     DUPLICATE_TAG_NAME(false, 2019, "중복된 태그 이름입니다."),
     MAX_TAG_LIMIT_EXCEEDED(false, 2020, "등록할 수 있는 태그의 수는 최대 5개 입니다."),
 
-
+    // mypage
+    PASSWORD_CONFIRMATION_EMPTY(false,2021,"비밀번호 확인을 입력해주세요."),
+    EMPTY_PASSWORD(false,2022,"비밀번호를 입력해주세요."),
 
     /**
      * 3000 : Response 오류

--- a/src/main/java/com/example/humorie/mypage/dto/response/GetUserInfoResDto.java
+++ b/src/main/java/com/example/humorie/mypage/dto/response/GetUserInfoResDto.java
@@ -9,5 +9,6 @@ public class GetUserInfoResDto {
     private Long id;
     private String email; // 이메일
     private String accountName;// 아이디
+    private String name; // 이름
     private Boolean emailSubscription; // 이메일 수신
 }

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
@@ -1,6 +1,8 @@
 package com.example.humorie.mypage.service;
 
 import com.example.humorie.consultant.consult_detail.repository.ConsultDetailRepository;
+import com.example.humorie.consultant.consult_detail.service.ConsultDetailService;
+import com.example.humorie.consultant.review.service.TagService;
 import com.example.humorie.global.config.SecurityConfig;
 import com.example.humorie.account.entity.AccountDetail;
 import com.example.humorie.account.jwt.PrincipalDetails;
@@ -12,6 +14,7 @@ import com.example.humorie.mypage.dto.request.UserInfoDelete;
 import com.example.humorie.mypage.dto.request.UserInfoUpdate;
 import com.example.humorie.mypage.dto.response.GetUserInfoResDto;
 import com.example.humorie.reservation.repository.ReservationRepository;
+import com.example.humorie.reservation.service.ReservationService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +30,9 @@ public class UserInfoService {
     private final ReservationRepository reservationRepository;
     private final UserInfoValidationService userInfoValidationService;
     private final SecurityConfig jwtSecurityConfig;
+    private final ConsultDetailService consultDetailService;
+    private final ReservationService reservationService;
+    private final TagService tagService;
 
     // 사용자 정보 조회
     public GetUserInfoResDto getMyAccount(PrincipalDetails principalDetails) {
@@ -81,11 +87,15 @@ public class UserInfoService {
         userInfoValidationService.validatePassword(deleteDto.getPassword());
         userInfoValidationService.validatePasswordMatch(deleteDto.getPassword(), account.getPassword());
 
-        // 상담 내역 삭제
-         consultDetailRepository.deleteByAccount_Id(account.getId());
+        // 상담 내역 소프트 삭제 및 외래 키 참조 제거
+        consultDetailService.softDeleteConsultDetailsByAccountId(account.getId());
+        consultDetailService.detachAccountFromConsultDetail(account.getId());
 
-        // 예약 삭제
-        reservationRepository.deleteByAccount_Id(account.getId());
+        // 예약 소프트 삭제 처리 및 외래 키 참조 제거
+        reservationService.detachAccountFromReservation(account.getId());
+
+        // 태그 외래 키 참조 제거
+        tagService.detachAccountFromTag(account.getId());
 
         // 리뷰 삭제
         reviewRepository.deleteByAccount_Id(account.getId());

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
@@ -49,17 +49,17 @@ public class UserInfoService {
     public String updateUserInfo(PrincipalDetails principalDetails, UserInfoUpdate updateDto) {
         AccountDetail account = principalDetails.getAccountDetail();
 
-        // 유효성 검사 및 필드 업데이트
         // 이름 (필수)
         userInfoValidationService.validateName(updateDto.getName());
         account.setName(updateDto.getName());
 
         // 비밀번호 (선택 사항)
-        if (updateDto.getNewPassword() != null && !updateDto.getNewPassword().isEmpty()) {
-            userInfoValidationService.validatePassword(updateDto.getNewPassword());
-            userInfoValidationService.validatePasswordConfirmation(updateDto.getNewPassword(), updateDto.getPasswordCheck());
-            account.setPassword(jwtSecurityConfig.passwordEncoder().encode(updateDto.getNewPassword()));
-        }
+        // 비밀번호 형식 검사
+        userInfoValidationService.validatePassword(updateDto.getNewPassword());
+        // 비밀번호 확인 필드 검사
+        userInfoValidationService.validatePasswordConfirmation(updateDto.getNewPassword(), updateDto.getPasswordCheck());
+        // 비밀번호가 유효하다면 암호화 후 저장
+        account.setPassword(jwtSecurityConfig.passwordEncoder().encode(updateDto.getNewPassword()));
 
         // 이메일 수신 여부 체크 (선택 사항)
         if (updateDto.getEmailSubscription() != null) {

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoService.java
@@ -37,10 +37,11 @@ public class UserInfoService {
         }
 
         return GetUserInfoResDto.builder()
-                .accountName(account.getAccountName())
-                .email(account.getEmail())
-                .id(account.getId())
-                .emailSubscription(account.getEmailSubscription())
+                .id(account.getId()) // 식별자
+                .email(account.getEmail()) // 이메일
+                .accountName(account.getAccountName()) // 아이디
+                .name(account.getName()) // 이름
+                .emailSubscription(account.getEmailSubscription()) // 이메일 확인
                 .build();
     }
 

--- a/src/main/java/com/example/humorie/mypage/service/UserInfoValidationService.java
+++ b/src/main/java/com/example/humorie/mypage/service/UserInfoValidationService.java
@@ -18,16 +18,16 @@ public class UserInfoValidationService {
 
     // 이름 유효성 검사
     public void validateName(String name) {
-        // 영어 알파벳(대소문자), 숫자, 그리고 자음과 모음이 결합된 완성된 한글로만 이루어진 문자열을 허용
-        // 그 외의 특수 문자나 미완성된 자모음 등은 허용하지 않음
-        String nameRegex = "^[a-zA-Z0-9가-힣]*$";
-        Pattern namePattern = Pattern.compile(nameRegex);
-        Matcher nameMatcher = namePattern.matcher(name);
-
         // null 또는 빈 값 체크 (추가 가능)
         if (name == null || name.isEmpty()) {
             throw new ErrorException(ErrorCode.EMPTY_NAME);
         }
+
+        // 자음과 모음이 결합된 완성된 한글로만 이루어진 문자열을 허용
+        // 영어, 숫자, 특수 문자는 허용하지 않음
+        String nameRegex = "^[가-힣]*$";
+        Pattern namePattern = Pattern.compile(nameRegex);
+        Matcher nameMatcher = namePattern.matcher(name);
 
         if (!nameMatcher.matches()) {
             throw new ErrorException(ErrorCode.INVALID_NAME);
@@ -36,6 +36,10 @@ public class UserInfoValidationService {
 
     // 비밀번호 유효성 검사
     public void validatePassword(String newPassword) {
+        if (newPassword == null || newPassword.isEmpty()) {
+            throw new ErrorException(ErrorCode. EMPTY_PASSWORD);
+        }
+
         String passwordRegex = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,16}$";
         Pattern pwPattern = Pattern.compile(passwordRegex);
         Matcher pwMatcher = pwPattern.matcher(newPassword);
@@ -47,6 +51,10 @@ public class UserInfoValidationService {
 
     // 비밀번호 재확인
     public void validatePasswordConfirmation(String newPassword, String passwordCheck) {
+        if (passwordCheck == null || passwordCheck.isEmpty()) {
+            throw new ErrorException(ErrorCode.PASSWORD_CONFIRMATION_EMPTY);
+        }
+
         if (!newPassword.equals(passwordCheck)) {
             throw new ErrorException(ErrorCode.PASSWORD_MISMATCH);
         }

--- a/src/main/java/com/example/humorie/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/humorie/reservation/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package com.example.humorie.reservation.repository;
 import com.example.humorie.reservation.entity.Reservation;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Optional<Reservation> findReservationByReservationUid(String uid);
 
-    void deleteByAccount_Id(Long accountId);
+    @Modifying
+    @Query("UPDATE Reservation r SET r.account = NULL WHERE r.account.id = :accountId")
+    void detachAccountFromReservation(@Param("accountId") Long accountId);
+
 
 }

--- a/src/main/java/com/example/humorie/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/humorie/reservation/service/ReservationService.java
@@ -19,6 +19,7 @@ import com.example.humorie.reservation.dto.response.CreateReservationResDto;
 import com.example.humorie.reservation.dto.response.GetReservationResDto;
 import com.example.humorie.reservation.entity.Reservation;
 import com.example.humorie.reservation.repository.ReservationRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -176,6 +177,11 @@ public class ReservationService {
         }
 
         return new AvailableReservationTimesResDto(timeList);
+    }
+
+    @Transactional
+    public void detachAccountFromReservation(Long accountId) {
+        reservationRepository.detachAccountFromReservation(accountId);
     }
 
 }


### PR DESCRIPTION
** 회원 정보 조회 API
- 프론트엔드 요청으로 name 필드 추가

** 회원 정보 업데이트 API
- name 필드 정규식 자모음이 완성된 한글 문자열만 허용하도록 수정
- 비밀번호 유효성 검사, 비밀번호 재확인 정규식에 빈값 확인  로직 및 관련 에러 코드 추가

** 회원탈퇴
- 상담 내역 soft delete 로직 추가
- 예약, 태그 외래 키 참조 제거 로직 추가