### PR TITLE
[Fix/#80] 상담 내역 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/ConsultDetailListDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/ConsultDetailListDto.java
@@ -1,38 +1,57 @@
 package com.example.humorie.consultant.consult_detail.dto.response;
 
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
+import com.example.humorie.consultant.counselor.entity.Symptom;
+import com.example.humorie.consultant.counselor.repository.SymptomRepository;
+
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class ConsultDetailListDto {
     private final Long id;
-    private final Boolean status;
-    private final String counselorName;
-    private final String counselContent;
-    private final String location;
+    private final Long counselorId;
+    private final String counselorName; // 담당자명
+    private final Boolean status; // 상담 상태
+    private final List<String> symptoms; // 상담 영역
+    private final Boolean isOnline; // 상담방법
     private final LocalDate counselDate;
+    private final LocalTime counselTIme;
 
     @Builder
-    public ConsultDetailListDto(Long id, Boolean status, String counselorName, String counselContent, String location, LocalDate counselDate) {
+    public ConsultDetailListDto(Long id, Long counselorId, String counselorName, Boolean status,
+                                Boolean isOnline, LocalDate counselDate, LocalTime counselTIme, List<String> symptoms) {
         this.id = id;
-        this.status = status;
+        this.counselorId = counselorId;
         this.counselorName = counselorName;
-        this.counselContent = counselContent;
-        this.location = location;
+        this.status = status;
+        this.symptoms = symptoms; // 상담 영역
+        this.isOnline = isOnline;
         this.counselDate = counselDate;
+        this.counselTIme = counselTIme;
     }
 
-    public static ConsultDetailListDto fromEntity(ConsultDetail consultDetail) {
+    public static ConsultDetailListDto fromEntity(ConsultDetail consultDetail, SymptomRepository symptomRepository) {
+        // 상담사의 증상 데이터를 리스트로 가져옴
+        List<Symptom> symptoms = symptomRepository.findByCounselorId(consultDetail.getCounselor().getId());
+        List<String> symptomNames = symptoms.stream()
+                .map(Symptom::getSymptom) // Symptom 객체에서 symptom 필드만 추출
+                .collect(Collectors.toList());
+
         return ConsultDetailListDto.builder()
                 .id(consultDetail.getId())
-                .status(consultDetail.getStatus())
+                .counselorId(consultDetail.getCounselorId())
                 .counselorName(consultDetail.getCounselorName())
-                .counselContent(consultDetail.getCounselContent())
-                .location(consultDetail.getLocation())
+                .status(consultDetail.getStatus())
+                .symptoms(symptomNames)// 상담 영역
+                .isOnline(consultDetail.getIsOnline())
                 .counselDate(consultDetail.getCounselDate())
+                .counselTIme(consultDetail.getCounselTime())
                 .build();
     }
 }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/LatestConsultDetailResDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/LatestConsultDetailResDto.java
@@ -9,19 +9,21 @@ import java.time.LocalDate;
 @Getter
 public class LatestConsultDetailResDto {
     private final Long id;
+    private final Long counselorId;
     private final String counselorName;
     private final double rating;
-    private final String location;
+    private final Boolean isOnline;
     private final LocalDate counselDate;
     private final String title;
     private final String content;
 
     @Builder
-    public LatestConsultDetailResDto(Long id, String counselorName, LocalDate counselDate, String status, String title, String symptom, String content, double rating, String location) {
+    public LatestConsultDetailResDto(Long id, Long counselorId, String counselorName, LocalDate counselDate, String title, String content, double rating, Boolean isOnline) {
         this.id = id;
+        this.counselorId = counselorId;
         this.counselorName = counselorName;
         this.rating = rating;
-        this.location = location;
+        this.isOnline = isOnline;
         this.counselDate = counselDate;
         this.title = title;
         this.content = content;
@@ -30,12 +32,13 @@ public class LatestConsultDetailResDto {
     public static LatestConsultDetailResDto fromEntity(ConsultDetail consultDetail) {
         return LatestConsultDetailResDto.builder()
                 .id(consultDetail.getId())
+                .counselorId(consultDetail.getCounselorId())
                 .counselorName(consultDetail.getCounselorName())
+                .rating(consultDetail.getRating())
+                .isOnline(consultDetail.getIsOnline())
                 .counselDate(consultDetail.getCounselDate())
                 .title(consultDetail.getTitle())
                 .content(consultDetail.getContent())
-                .rating(consultDetail.getRating())
-                .location(consultDetail.getLocation())
                 .build();
     }
 }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
@@ -1,52 +1,69 @@
 package com.example.humorie.consultant.consult_detail.dto.response;
 
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
+import com.example.humorie.consultant.counselor.entity.Symptom;
+import com.example.humorie.consultant.counselor.repository.SymptomRepository;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class SpecificConsultDetailDto {
     private final Long id;
-    private final Long counselorId;
-    private final String counselorName;
-    private final String content;
-    private final Boolean status;
-    private final String symptom;
-    private final String title;
-    private final LocalDate counselDate;
-    private final LocalTime counselTime;
-    private final String location;
+    private final Long counselorId; // 상담사 식별자
+    private final String counselorName; // 상담사 이름
+    private final List<String> symptoms; // 상담 영역
+    private final Boolean isOnline; // 온오프라인
+    private final String location; // 지역
+    private final Boolean status; // 상태
+    private final String title; // 상담 제목
+    private final String symptom; // 상담 증상
+    private final String content; // 상담 내용
+    private final LocalDate counselDate; // 상담 날짜
+    private final LocalTime counselTime; // 상담 시간
 
     @Builder
-    public SpecificConsultDetailDto(Long id, Long counselorId, String counselorName, String content, Boolean status, String symptom, String title, LocalDate counselDate, LocalTime counselTime, String location) {  // Boolean 타입으로 설정
+    public SpecificConsultDetailDto(Long id, Long counselorId, String counselorName, List<String> symptoms, Boolean isOnline,
+                                    Boolean status, String title, String symptom, String content, LocalDate counselDate, LocalTime counselTime, String location) {  // Boolean 타입으로 설정
         this.id = id;
-        this.counselorId = counselorId;;
+        this.counselorId = counselorId;
         this.counselorName = counselorName;
-        this.content = content;
+        this.symptoms = symptoms;
+        this.isOnline = isOnline;
+        this.location = location;
         this.status = status;
-        this.symptom = symptom;
         this.title = title;
+        this.symptom = symptom;
+        this.content = content;
         this.counselDate = counselDate;
         this.counselTime = counselTime;
-        this.location = location;
     }
 
     // ConsultDetail 엔티티에서 DTO로 변환하는 메서드
-    public static SpecificConsultDetailDto fromEntity(ConsultDetail consultDetail) {
+    public static SpecificConsultDetailDto fromEntity(ConsultDetail consultDetail, SymptomRepository symptomRepository) {
+        // 상담사의 증상 데이터를 리스트로 가져옴
+        List<Symptom> symptoms = symptomRepository.findByCounselorId(consultDetail.getCounselor().getId());
+        List<String> symptomNames = symptoms.stream()
+                .map(Symptom::getSymptom) // Symptom 객체에서 symptom 필드만 추출
+                .collect(Collectors.toList());
+
         return SpecificConsultDetailDto.builder()
                 .id(consultDetail.getId())
                 .counselorId(consultDetail.getCounselor().getId())
                 .counselorName(consultDetail.getCounselor().getName())
-                .content(consultDetail.getContent())
+                .symptoms(symptomNames)// 상담 영역
+                .isOnline(consultDetail.getIsOnline())
+                .location(consultDetail.getReservation().getLocation())
                 .status(consultDetail.getStatus())
-                .symptom(consultDetail.getSymptom())
                 .title(consultDetail.getTitle())
+                .symptom(consultDetail.getSymptom())
+                .content(consultDetail.getContent())
                 .counselDate(consultDetail.getCounselDate())
                 .counselTime(consultDetail.getCounselTime())
-                .location(consultDetail.getReservation().getLocation())
                 .build();
     }
 }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
@@ -49,6 +49,8 @@ public class ConsultDetail {
 
     public String getContent()  { return content; }
 
+    public Long getCounselorId() { return counselor.getId(); }
+
     public String getCounselorName() {
         return counselor.getName();
     }
@@ -57,6 +59,7 @@ public class ConsultDetail {
         return counselor.getRating();
     }
 
+    public Boolean getIsOnline() { return reservation.getIsOnline(); }
     public String getLocation() {
         return reservation.getLocation();
     }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -122,7 +122,7 @@ public class ConsultDetailService {
             throw new ErrorException(ErrorCode.CONSULT_DETAIL_NOT_COMPLETED);
         }
 
-        return SpecificConsultDetailDto.fromEntity(consultDetail);
+        return SpecificConsultDetailDto.fromEntity(consultDetail, symptomRepository);
     }
 
     @Transactional

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -9,6 +9,7 @@ import com.example.humorie.account.jwt.PrincipalDetails;
 import com.example.humorie.consultant.consult_detail.dto.response.SpecificConsultDetailDto;
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.consultant.consult_detail.repository.ConsultDetailRepository;
+import com.example.humorie.consultant.counselor.repository.SymptomRepository;
 import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
 import jakarta.transaction.Transactional;
@@ -28,6 +29,7 @@ import java.util.List;
 public class ConsultDetailService {
     private final AccountService accountService;
     private final ConsultDetailRepository consultDetailRepository;
+    private final SymptomRepository symptomRepository;
 
     // 가장 최근에 받은 상담 조회
     public LatestConsultDetailResDto getLatestConsultDetailResponse(PrincipalDetails principalDetails) {
@@ -81,19 +83,22 @@ public class ConsultDetailService {
         // Page 객체를 가져옴
         Page<ConsultDetail> consultDetails = consultDetailRepository.findAllConsultDetail(accountDetail, pageable);
 
-        // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
-        if (pageable.getPageNumber() >= consultDetails.getTotalPages()) {
-            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, consultDetails.getTotalPages());
-            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
-        }
-
-        // 페이지가 비어 있는지 확인
+        // 데이터가 없는 경우 예외 처리
         if (consultDetails.isEmpty()) {
             throw new ErrorException(ErrorCode.NO_RECENT_CONSULT_DETAIL);
         }
 
+        // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
+//        if (pageable.getPageNumber() >= consultDetails.getTotalPages()) {
+//            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, consultDetails.getTotalPages());
+//            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+//        }
+
         // Page 객체를 ConsultDetailListDto로 변환
-        Page<ConsultDetailListDto> consultDetailListDtos = consultDetails.map(ConsultDetailListDto::fromEntity);
+        Page<ConsultDetailListDto> consultDetailListDtos = consultDetails.map(consultDetail ->
+                        ConsultDetailListDto.fromEntity(consultDetail, symptomRepository)
+        );
+
         log.info("Requested page number (0-based): {}", pageable.getPageNumber());
         log.info("Total pages available: {}", consultDetailListDtos.getTotalPages());
 

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -174,28 +174,42 @@ public class DataInitializer implements CommandLineRunner {
                 .isOnline(false).location("서울 강남구").counselor(counselor1).counselContent("학업/진로").reservationUid(String.valueOf(UUID.randomUUID())).payment(payment1).build();
         Reservation reservation2 = Reservation.builder().counselDate(LocalDate.of(2024,8,19)).account(accountDetail2).counselTime(LocalTime.of(15,30))
                 .isOnline(false).location("인천 연수구").counselor(counselor2).counselContent("대인관계").reservationUid(String.valueOf(UUID.randomUUID())).payment(payment2).build();
-        Reservation reservation3 = Reservation.builder().counselDate(LocalDate.of(2024,8,20)).account(accountDetail1).counselTime(LocalTime.of(16,0))
+        Reservation reservation3 = Reservation.builder().counselDate(LocalDate.of(2024,8,19)).account(accountDetail1).counselTime(LocalTime.of(16,0))
                 .isOnline(false).location("서울 은평구").counselor(counselor3).counselContent("정신건강").reservationUid(String.valueOf(UUID.randomUUID())).payment(payment3).build();
         Reservation reservation4 = Reservation.builder().counselDate(LocalDate.of(2024,8,21)).account(accountDetail2).counselTime(LocalTime.of(14,0))
                 .isOnline(true).location("Zoom").counselor(counselor2).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).payment(payment4).build();
+        Reservation reservation5 = Reservation.builder().counselDate(LocalDate.of(2024,8,21)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(true).location("Google meet").counselor(counselor2).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation6 = Reservation.builder().counselDate(LocalDate.of(2024,8,22)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(false).location("인천 미추홀구").counselor(counselor4).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation7 = Reservation.builder().counselDate(LocalDate.of(2024,8,23)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(false).location("성남시 분당구").counselor(counselor5).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation8 = Reservation.builder().counselDate(LocalDate.of(2024,8,24)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(true).location("전화상담").counselor(counselor6).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation9 = Reservation.builder().counselDate(LocalDate.of(2024,8,25)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(true).location("전화상담").counselor(counselor1).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation10 = Reservation.builder().counselDate(LocalDate.of(2024,8,26)).account(accountDetail1).counselTime(LocalTime.of(11,0))
+                .isOnline(false).location("인천 부평구").counselor(counselor2).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
+        Reservation reservation11 = Reservation.builder().counselDate(LocalDate.of(2024,8,26)).account(accountDetail1).counselTime(LocalTime.of(14,0))
+                .isOnline(false).location("서울 종로구").counselor(counselor3).counselContent("성격").reservationUid(String.valueOf(UUID.randomUUID())).build();
 
         ConsultDetail consultDetail1 = ConsultDetail.builder().status(true).account(accountDetail1).counselor(counselor1).reservation(reservation1).content("상담 내용 1")
                 .symptom("스트레스").title("상담 제목 1").build();
-        ConsultDetail consultDetail2 = ConsultDetail.builder().status(true).account(accountDetail1).counselor(counselor2).reservation(reservation2).content("상담 내용 2")
+        ConsultDetail consultDetail2 = ConsultDetail.builder().status(true).account(accountDetail1).counselor(counselor2).reservation(reservation3).content("상담 내용 2")
                 .symptom("우울").title("상담 제목 2").build();
-        ConsultDetail consultDetail3 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor3).reservation(reservation3).content("상담 내용 3")
+        ConsultDetail consultDetail3 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor3).reservation(reservation5).content("상담 내용 3")
                 .symptom("불안").title("상담 제목 3").build();
-        ConsultDetail consultDetail4 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor4).reservation(reservation3).content("상담 내용 4")
+        ConsultDetail consultDetail4 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor4).reservation(reservation6).content("상담 내용 4")
                 .symptom("트라우마").title("상담 제목 4").build();
-        ConsultDetail consultDetail5 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor5).reservation(reservation3).content("상담 내용 5")
+        ConsultDetail consultDetail5 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor5).reservation(reservation7).content("상담 내용 5")
                 .symptom("스트레스").title("상담 제목 5").build();
-        ConsultDetail consultDetail6 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor6).reservation(reservation3).content("상담 내용 6")
+        ConsultDetail consultDetail6 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor6).reservation(reservation8).content("상담 내용 6")
                 .symptom("우울").title("상담 제목 6").build();
-        ConsultDetail consultDetail7 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor1).reservation(reservation3).content("상담 내용 7")
+        ConsultDetail consultDetail7 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor1).reservation(reservation9).content("상담 내용 7")
                 .symptom("불안").title("상담 제목 7").build();
-        ConsultDetail consultDetail8 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor2).reservation(reservation3).content("상담 내용 8")
+        ConsultDetail consultDetail8 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor2).reservation(reservation10).content("상담 내용 8")
                 .symptom("트라우마").title("상담 제목 8").build();
-        ConsultDetail consultDetail9 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor3).reservation(reservation3).content("상담 내용 9")
+        ConsultDetail consultDetail9 = ConsultDetail.builder().status(false).account(accountDetail1).counselor(counselor3).reservation(reservation11).content("상담 내용 9")
                 .symptom("스트레스").title("상담 제목 9").build();
         ConsultDetail consultDetail10 = ConsultDetail.builder().status(false).account(accountDetail2).counselor(counselor4).reservation(reservation3).content("상담 내용 10")
                 .symptom("우울").title("상담 제목 10").build();
@@ -289,7 +303,7 @@ public class DataInitializer implements CommandLineRunner {
         educationRepository.saveAll(Arrays.asList(education1, education2, education3, education4, education5, education6));
         careerRepository.saveAll(Arrays.asList(career1, career2, career3, career4, career5, career6, career7, career8));
         pointRepository.saveAll(Arrays.asList(point1, point2, point3, point4, point5, point6, point7));
-        reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4));
+        reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4, reservation5, reservation6,reservation7, reservation8, reservation9, reservation10, reservation11));
         consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail2, consultDetail3, consultDetail4, consultDetail5, consultDetail6, consultDetail7, consultDetail8, consultDetail9, consultDetail10, consultDetail1, consultDetail12, consultDetail13, consultDetail14, consultDetail15, consultDetail16, consultDetail17, consultDetail18));
         tagRepository.saveAll(Arrays.asList(tag1, tag2, tag3, tag4, tag5, tag6));
         noticeRepository.saveAll(notices);


### PR DESCRIPTION
** 가장 최근에 받은 상담 조회
- 프론트엔드 요청으로 상담사 식별자 필드 및 isOnline 필드(온/오프라인 분류) 추가

**전체 상담 내역 조회 API
- 프론트 요청으로 symptoms를 리스트로 변경
- 상담사 식별자 필드 및 isOnline 필드 추가

** 특정 상담 내역 조회
- 상담사 식별자 필드 및 isOnline 필드 추가

+) Reservation 더미 데이터 추가하여 날짜, 시간 순으로 정렬되는지 다시 한 번 점검하였습니다. 