### PR TITLE
{Fix/#84] 공지사항 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -275,26 +275,21 @@ public class DataInitializer implements CommandLineRunner {
         Tag tag5 = Tag.builder().tagName("좋아요").tagContent("상담이 매우 좋았습니다.").account(accountDetail2).build();
         Tag tag6 = Tag.builder().tagName("아쉬움").tagContent("상담이 아쉬웠습니다.").account(accountDetail2).build();
 
-        List<Notice> notices = new ArrayList<>();
-        int importanceCount = 0;
+        Notice notice1 = Notice.builder().importance(true).title("공지사항 제목 1").content("공지사항 내용 1").
+                createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(18,00,00)).viewCount(50).author("관리자").build();
+        Notice notice2 = Notice.builder().importance(false).title("공지사항 제목 2").content("공지사항 내용 2").
+                createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(15,00,00)).viewCount(50).author("관리자").build();
+        Notice notice3 = Notice.builder().importance(true).title("공지사항 제목 3").content("공지사항 내용 3").
+                createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(12,00,00)).viewCount(40).author("관리자").build();
+        Notice notice4 = Notice.builder().importance(false).title("공지사항 제목 4").content("공지사항 내용 4").
+                createdDate(LocalDate.of(2024, 8, 24)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
+        Notice notice5 = Notice.builder().importance(true).title("공지사항 제목 5").content("공지사항 내용 5").
+                createdDate(LocalDate.of(2024, 8, 23)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
+        Notice notice6 = Notice.builder().importance(false).title("공지사항 제목 6").content("공지사항 내용 6").
+                createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
+        Notice notice7 = Notice.builder().importance(false  ).title("공지사항 제목 7").content("공지사항 내용 7").
+                createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(14,00,00)).viewCount(25).author("관리자").build();
 
-        for (int i = 1; i <= 10; i++) {
-            boolean isImportant = importanceCount < 3;  // 처음 3개만 중요
-            if (isImportant) {
-                importanceCount++;
-            }
-
-            Notice notice = Notice.builder()
-                    .title("공지사항 제목 " + i)
-                    .content("이것은 공지사항 내용 " + i + "입니다.")
-                    .importance(isImportant)
-                    .createdDate(LocalDate.now().minusDays(i / 2))  // 두 개씩 같은 날짜로 설정
-                    .createdTime(LocalTime.of(9, 0).plusHours(i))   // 시간을 다르게 설정
-                    .viewCount(i * 10)
-                    .author("작성자 " + i)
-                    .build();
-            notices.add(notice);
-        }
 
         counselorRepository.saveAll(Arrays.asList(counselor1, counselor2, counselor3, counselor4, counselor5, counselor6));
         methodRepository.saveAll(Arrays.asList(method1, method2, method3, method4, method5, method6, method7, method8));
@@ -307,7 +302,7 @@ public class DataInitializer implements CommandLineRunner {
         reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4, reservation5, reservation6,reservation7, reservation8, reservation9, reservation10, reservation11));
         consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail2, consultDetail3, consultDetail4, consultDetail5, consultDetail6, consultDetail7, consultDetail8, consultDetail9, consultDetail10, consultDetail1, consultDetail12, consultDetail13, consultDetail14, consultDetail15, consultDetail16, consultDetail17, consultDetail18));
         tagRepository.saveAll(Arrays.asList(tag1, tag2, tag3, tag4, tag5, tag6));
-        noticeRepository.saveAll(notices);
+        noticeRepository.saveAll(Arrays.asList(notice1,notice2,notice3,notice4,notice5,notice6,notice7));
     }
 
 }

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -55,8 +55,8 @@ public class NoticeController {
     @Operation(summary = "공지사항 검색")
     public NoticePageDto searchNotices(
             @RequestParam(required = false) String keyword,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "9") int size
+            @RequestParam int page,
+            @RequestParam int size
     ) {
         // 페이지 번호에 대한 유효성 검사
         if (page < 0) {

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -31,8 +31,8 @@ public class NoticeController {
     @GetMapping("/get")
     @Operation(summary = "공지사항 전체 조회")
     public NoticePageDto getAllNotices(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "9") int size
+            @RequestParam int page,
+            @RequestParam int size
     ) {
         // 페이지 번호에 대한 유효성 검사
         if (page < 0) {
@@ -42,7 +42,8 @@ public class NoticeController {
         // 페이지 크기에 대한 유효성 검사
         if (size < 1) {
             throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
-        } else if (size > 9) {
+        }
+        if (size > 9) {
             throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
         }
 

--- a/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Getter
 @Builder
@@ -13,6 +14,7 @@ public class GetAllNoticeDto {
     private boolean importance;
     private String title;
     private LocalDate createdDate;
+    private LocalTime createdTime;
     private int viewCount;
 
     // Notice 엔티티를 GetAllNoticeDto로 변환하는 메서드
@@ -22,6 +24,7 @@ public class GetAllNoticeDto {
                 .importance(notice.isImportance())
                 .title(notice.getTitle())
                 .createdDate(notice.getCreatedDate())
+                .createdTime(notice.getCreatedTime())
                 .viewCount(notice.getViewCount())
                 .build();
     }

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -17,8 +18,9 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @Query("SELECT n FROM Notice n WHERE n.importance = true ORDER BY n.createdDate DESC, n.createdTime DESC")
     List<Notice> findImportantNotices(Pageable pageable);
 
-    // 제목 또는 내용에 검색어가 포함된 공지사항을 검색
-    Page<Notice> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
+    // 제목이나 내용에 키워드가 포함된 공지사항을 검색하는 메서드
+    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdDate DESC, n.createdTime DESC")
+    Page<Notice> findByTitleContainingOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
 
     // 공지사항을 날짜와 시간 순으로 내림차순 정렬하여 전체 목록 반환
     List<Notice> findAllByOrderByCreatedDateDescCreatedTimeDesc();

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +25,6 @@ public class NoticeService {
 
     public NoticePageDto getAllNotices(Pageable pageable) {
         Page<Notice> noticePage = noticeRepository.findImportantAndRecentNotices(pageable);
-
-
 
         // 페이지가 비어 있는지 확인
         if (noticePage.isEmpty()) {
@@ -41,42 +40,26 @@ public class NoticeService {
         // 중요 공지사항 먼저 가져오기
         List<Notice> importantNotices = noticeRepository.findImportantNotices(pageable);
 
-        // 검색 결과 가져오기
-        Page<Notice> searchResults = noticeRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+        // 키워드 검색 결과 가져오기
+        Page<Notice> searchResults = noticeRepository.findByTitleContainingOrContentContaining(keyword, pageable);
 
-        // 검색 결과가 비어 있을 경우 예외 처리
-        if (importantNotices.isEmpty() && searchResults.isEmpty()) {
-            throw new ErrorException(ErrorCode.NO_SEARCH_RESULTS);
-        }
+        // 두 리스트를 병합하되, 중요 공지사항이 먼저 오도록 배치
+        List<Notice> combinedResults = new ArrayList<>();
+        combinedResults.addAll(importantNotices);  // 중요 공지사항 먼저 추가
+        combinedResults.addAll(searchResults.getContent());  // 그 아래에 키워드 검색 결과 추가
 
-        // 중요 공지사항과 검색 결과를 병합하고 중복 제거
-        Set<Notice> distinctResults = new LinkedHashSet<>();
-        distinctResults.addAll(importantNotices);
-        distinctResults.addAll(searchResults.getContent());
+        // 중요 공지사항은 항상 상단에 오므로, 전체 리스트는 정렬하지 않음
 
-        // 병합된 결과를 날짜 및 시간 순으로 정렬
-        List<Notice> sortedResults = new ArrayList<>(distinctResults);
-        sortedResults.sort((n1, n2) -> {
-            // 두 공지사항의 createdDate(생성일자)가 동일한 경우, createdTime(생성시간)을 비교
-            if (n1.getCreatedDate().isEqual(n2.getCreatedDate())) {
-                return n2.getCreatedTime().compareTo(n1.getCreatedTime());
-            }
-            // 날짜가 최신일수록 리스트의 앞쪽에 위치
-            return n2.getCreatedDate().compareTo(n1.getCreatedDate());
-        });
+        // 결과를 DTO로 변환
+        List<GetAllNoticeDto> dtoList = combinedResults.stream()
+                .map(GetAllNoticeDto::fromEntity)
+                .collect(Collectors.toList());
 
-        // 병합된 결과를 DTO로 변환
-        List<GetAllNoticeDto> dtoList = new ArrayList<>();
-        for (Notice notice : sortedResults) {
-            dtoList.add(GetAllNoticeDto.fromEntity(notice));
-        }
         // 병합된 결과를 페이지네이션
-        // 페이지네이션을 위해 시작점(start)과 끝점(end) 인덱스를 계산
         int start = Math.min((int) pageable.getOffset(), dtoList.size());
-        int end = Math.min((start + pageable.getPageSize()), dtoList.size());
+        int end = Math.min(start + pageable.getPageSize(), dtoList.size());
 
-        // 페이지 번호가 전체 페이지 수를 초과하는 경우 예외 처리
-        if (pageable.getPageNumber() >= Math.ceil((double) dtoList.size() / pageable.getPageSize())) {
+        if (start >= dtoList.size()) {
             throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
         }
 

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -25,10 +25,7 @@ public class NoticeService {
     public NoticePageDto getAllNotices(Pageable pageable) {
         Page<Notice> noticePage = noticeRepository.findImportantAndRecentNotices(pageable);
 
-        // 페이지 번호가 전체 페이지 수를 초과하는 경우
-        if (pageable.getPageNumber() >= noticePage.getTotalPages()) {
-            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
-        }
+
 
         // 페이지가 비어 있는지 확인
         if (noticePage.isEmpty()) {


### PR DESCRIPTION
** 공지사항 더미데이터 수정
- for 문으로 랜덤하게 생성한 데이터를 기존 더미데이터 형식에 맞춤

** 공지사항 전체 조회
- Request Param(page,size)의 default value 삭제
- 날짜 뿐만 아니라 시간순으로 배열이 잘 되는지 시간 필드도 추가

** 공지사항 검색
- 프론트엔드 요청으로 공지사항 검색 로직 수정
- 중요도 우선 배치+날짜 시간 순 정렬
- 검색결과는 중요도 밑에 날짜 시간 순으로 정렬되도록 수정
- 중요 공지사항이어도 검색 결과가 있는 경우 중복 배치(학교 공지사항 참고해서 구현)