### PR TITLE
{Fix/#92]  날짜 형식 포맷 및 데이터가 없는 경우 로직 수정

### DIFF
--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/ConsultDetailListDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/ConsultDetailListDto.java
@@ -4,6 +4,7 @@ import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.consultant.counselor.entity.Symptom;
 import com.example.humorie.consultant.counselor.repository.SymptomRepository;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,6 +21,8 @@ public class ConsultDetailListDto {
     private final Boolean status; // 상담 상태
     private final List<String> symptoms; // 상담 영역
     private final Boolean isOnline; // 상담방법
+    // 날짜 필드에 @JsonFormat 애너테이션 적용
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.M.d")
     private final LocalDate counselDate;
     private final LocalTime counselTIme;
 

--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/LatestConsultDetailResDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/LatestConsultDetailResDto.java
@@ -1,6 +1,7 @@
 package com.example.humorie.consultant.consult_detail.dto.response;
 
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,18 +13,19 @@ public class LatestConsultDetailResDto {
     private final Long counselorId;
     private final String counselorName;
     private final double rating;
-    private final Boolean isOnline;
+    // 날짜 필드에 @JsonFormat 애너테이션 적용
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.M.d")
     private final LocalDate counselDate;
     private final String title;
     private final String content;
 
     @Builder
-    public LatestConsultDetailResDto(Long id, Long counselorId, String counselorName, LocalDate counselDate, String title, String content, double rating, Boolean isOnline) {
+    public LatestConsultDetailResDto(Long id, Long counselorId, String counselorName, LocalDate counselDate,
+                                     String title, String content, double rating) {
         this.id = id;
         this.counselorId = counselorId;
         this.counselorName = counselorName;
         this.rating = rating;
-        this.isOnline = isOnline;
         this.counselDate = counselDate;
         this.title = title;
         this.content = content;
@@ -35,7 +37,6 @@ public class LatestConsultDetailResDto {
                 .counselorId(consultDetail.getCounselorId())
                 .counselorName(consultDetail.getCounselorName())
                 .rating(consultDetail.getRating())
-                .isOnline(consultDetail.getIsOnline())
                 .counselDate(consultDetail.getCounselDate())
                 .title(consultDetail.getTitle())
                 .content(consultDetail.getContent())

--- a/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/dto/response/SpecificConsultDetailDto.java
@@ -3,6 +3,7 @@ package com.example.humorie.consultant.consult_detail.dto.response;
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.consultant.counselor.entity.Symptom;
 import com.example.humorie.consultant.counselor.repository.SymptomRepository;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,6 +24,8 @@ public class SpecificConsultDetailDto {
     private final String title; // 상담 제목
     private final String symptom; // 상담 증상
     private final String content; // 상담 내용
+    // 날짜 필드에 @JsonFormat 애너테이션 적용
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.M.d")
     private final LocalDate counselDate; // 상담 날짜
     private final LocalTime counselTime; // 상담 시간
 

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,11 +45,14 @@ public class ConsultDetailService {
         // Pageable을 사용하여 결과를 하나로 제한
         List<ConsultDetail> consultDetails = consultDetailRepository.findLatestConsultDetail(accountDetail, PageRequest.of(0, 1));
 
-        // 첫 번째 결과만 선택, 없으면 예외 발생
-        ConsultDetail consultDetail = consultDetails.stream().findFirst().orElseThrow(() -> {
+        // 첫 번째 결과만 선택, 없으면 빈 객체 반환
+        ConsultDetail consultDetail = consultDetails.stream().findFirst().orElse(null);
+
+        if (consultDetail == null) {
             log.info("No consult details found for account ID: {}", accountDetail.getId());
-            return new ErrorException(ErrorCode.NO_RECENT_CONSULT_DETAIL);
-        });
+            // 빈 데이터를 초기화하여 반환
+            return new LatestConsultDetailResDto( null, null, "", null,  null,  "", 0.0);
+        }
 
         return LatestConsultDetailResDto.fromEntity(consultDetail);
     }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -14,6 +14,7 @@ import com.example.humorie.global.exception.ErrorCode;
 import com.example.humorie.global.exception.ErrorException;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -83,16 +85,17 @@ public class ConsultDetailService {
         // Page 객체를 가져옴
         Page<ConsultDetail> consultDetails = consultDetailRepository.findAllConsultDetail(accountDetail, pageable);
 
-        // 데이터가 없는 경우 예외 처리
-        if (consultDetails.isEmpty()) {
-            throw new ErrorException(ErrorCode.NO_RECENT_CONSULT_DETAIL);
+        // 데이터가 없는 경우 빈 Page 반환
+        if (consultDetails.getTotalPages() == 0) {
+            Page<ConsultDetailListDto> emptyPage = new PageImpl<>(new ArrayList<>(), PageRequest.of(page, size), 0);
+            return new ConsultDetailPageDto(emptyPage);
         }
 
         // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
-//        if (pageable.getPageNumber() >= consultDetails.getTotalPages()) {
-//            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, consultDetails.getTotalPages());
-//            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
-//        }
+        if (pageable.getPageNumber() >= consultDetails.getTotalPages()) {
+            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, consultDetails.getTotalPages());
+            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+        }
 
         // Page 객체를 ConsultDetailListDto로 변환
         Page<ConsultDetailListDto> consultDetailListDtos = consultDetails.map(consultDetail ->


### PR DESCRIPTION
** 가장 최근에 받은 상담 조회 API
- 데모 회의에서 '무료 온라인상담' 태그를 제거하기로 해서 isOnline 필드 삭제
- 프론트엔드 요청에 따라 consultDate(상담 날짜) 필드에 @JsonFormat 에너테이션을 추가 해 'yyyy.M.d'로 날짜 포맷
- 프론트엔드의 요청에 따라 데이터가 없는 경우 빈 데이터를 초기화하여 반환

** 전체 상담 내역 조회 API
- 상담 날짜 필드에 @JsonFormat 에너테이션 추가
- 프론트엔드의 요청에 따라 데이터가 없는 경우 빈 리스트 반환

** 특정 상담 내역 조회 API
- 상담 날짜 필드에 @JsonFormat 에너테이션 추가