### PR TITLE
[Fix/#94] 공지사항 API 수정

### DIFF
--- a/src/main/java/com/example/humorie/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/humorie/global/exception/ErrorCode.java
@@ -79,7 +79,7 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(false, 3013,"페이지 번호가 전체 페이지 수를 초과했습니다."),
     NEGATIVE_PAGE_NUMBER(false, 3014,"페이지 번호는 0 이상이어야 합니다."),
     INVALID_PAGE_SIZE(false, 3015,"페이지 크기가 최대 허용 값을 초과했습니다."),
-    NEGATIVE_PAGE_SIZE(false, 3016,"페이지 크기는 0 이상이어야 합니다."),
+    NEGATIVE_PAGE_SIZE(false, 3016,"페이지 크기는 0보다 커야 합니다."),
     NO_SEARCH_RESULTS(false, 3017,"검색 결과가 없습니다.");
 
 

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -303,6 +303,10 @@ public class DataInitializer implements CommandLineRunner {
                 createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
         Notice notice7 = Notice.builder().title("공지사항 제목 7").content("공지사항 내용 7").
                 createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(14,00,00)).viewCount(25).author("관리자").build();
+        Notice notice8 = Notice.builder().title("공지사항 제목 8").content("공지사항 내용 8").
+                createdDate(LocalDate.of(2024, 8, 21)).createdTime(LocalTime.of(14,00,00)).viewCount(30).author("관리자").build();
+        Notice notice9 = Notice.builder().title("공지사항 제목 9").content("공지사항 내용 9").
+                createdDate(LocalDate.of(2024, 8, 20)).createdTime(LocalTime.of(14,00,00)).viewCount(35).author("관리자").build();
 
 
         counselorRepository.saveAll(Arrays.asList(counselor1, counselor2, counselor3, counselor4, counselor5, counselor6));
@@ -316,7 +320,7 @@ public class DataInitializer implements CommandLineRunner {
         reservationRepository.saveAll(Arrays.asList(reservation1, reservation2, reservation3, reservation4, reservation5, reservation6,reservation7, reservation8, reservation9, reservation10, reservation11));
         consultDetailRepository.saveAll(Arrays.asList(consultDetail1, consultDetail2, consultDetail3, consultDetail4, consultDetail5, consultDetail6, consultDetail7, consultDetail8, consultDetail9, consultDetail10, consultDetail1, consultDetail12, consultDetail13, consultDetail14, consultDetail15, consultDetail16, consultDetail17, consultDetail18));
         tagRepository.saveAll(Arrays.asList(tag1, tag2, tag3, tag4, tag5, tag6));
-        noticeRepository.saveAll(Arrays.asList(notice1,notice2,notice3,notice4,notice5,notice6,notice7));
+        noticeRepository.saveAll(Arrays.asList(notice1,notice2,notice3,notice4,notice5,notice6,notice7,notice8,notice9));
     }
 
 }

--- a/src/main/java/com/example/humorie/global/init/DataInitializer.java
+++ b/src/main/java/com/example/humorie/global/init/DataInitializer.java
@@ -289,19 +289,19 @@ public class DataInitializer implements CommandLineRunner {
         Tag tag5 = Tag.builder().tagName("좋아요").tagContent("상담이 매우 좋았습니다.").account(accountDetail2).build();
         Tag tag6 = Tag.builder().tagName("아쉬움").tagContent("상담이 아쉬웠습니다.").account(accountDetail2).build();
 
-        Notice notice1 = Notice.builder().importance(true).title("공지사항 제목 1").content("공지사항 내용 1").
+        Notice notice1 = Notice.builder().title("공지사항 제목 1").content("공지사항 내용 1").
                 createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(18,00,00)).viewCount(50).author("관리자").build();
-        Notice notice2 = Notice.builder().importance(false).title("공지사항 제목 2").content("공지사항 내용 2").
+        Notice notice2 = Notice.builder().title("공지사항 제목 2").content("공지사항 내용 2").
                 createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(15,00,00)).viewCount(50).author("관리자").build();
-        Notice notice3 = Notice.builder().importance(true).title("공지사항 제목 3").content("공지사항 내용 3").
+        Notice notice3 = Notice.builder().title("공지사항 제목 3").content("공지사항 내용 3").
                 createdDate(LocalDate.of(2024, 8, 25)).createdTime(LocalTime.of(12,00,00)).viewCount(40).author("관리자").build();
-        Notice notice4 = Notice.builder().importance(false).title("공지사항 제목 4").content("공지사항 내용 4").
+        Notice notice4 = Notice.builder().title("공지사항 제목 4").content("공지사항 내용 4").
                 createdDate(LocalDate.of(2024, 8, 24)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
-        Notice notice5 = Notice.builder().importance(true).title("공지사항 제목 5").content("공지사항 내용 5").
+        Notice notice5 = Notice.builder().title("공지사항 제목 5").content("공지사항 내용 5").
                 createdDate(LocalDate.of(2024, 8, 23)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
-        Notice notice6 = Notice.builder().importance(false).title("공지사항 제목 6").content("공지사항 내용 6").
+        Notice notice6 = Notice.builder().title("공지사항 제목 6").content("공지사항 내용 6").
                 createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(18,00,00)).viewCount(25).author("관리자").build();
-        Notice notice7 = Notice.builder().importance(false  ).title("공지사항 제목 7").content("공지사항 내용 7").
+        Notice notice7 = Notice.builder().title("공지사항 제목 7").content("공지사항 내용 7").
                 createdDate(LocalDate.of(2024, 8, 22)).createdTime(LocalTime.of(14,00,00)).viewCount(25).author("관리자").build();
 
 

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -66,7 +66,7 @@ public class NoticeController {
         // 페이지 크기에 대한 유효성 검사
         if (size < 1) {
             throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
-        } else if (size > 9) {
+        } else if (size > 8) {
             throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
         }
 

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -44,26 +44,7 @@ public class NoticeController {
             @RequestParam int page,
             @RequestParam int size
     ) {
-        // 페이지 번호에 대한 유효성 검사
-        if (page < 0) {
-            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_NUMBER);
-        }
-
-        // 페이지 크기에 대한 유효성 검사
-        if (size < 1) {
-            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
-        } else if (size > 8) {
-            throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
-        }
-
-        Pageable pageable = PageRequest.of(page, size);
-
-        // 키워드가 없는 경우 전체 공지사항 반환
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return noticeService.getAllNotices(pageable);
-        }
-
-        return noticeService.searchNotices(keyword, pageable);
+        return noticeService.searchNotices(keyword, page, size);
     }
 
     @GetMapping("/{noticeId}")

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -34,21 +34,7 @@ public class NoticeController {
             @RequestParam int page,
             @RequestParam int size
     ) {
-        // 페이지 번호에 대한 유효성 검사
-        if (page < 0) {
-            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_NUMBER);
-        }
-
-        // 페이지 크기에 대한 유효성 검사
-        if (size < 1) {
-            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
-        }
-        if (size > 8) {
-            throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
-        }
-
-        Pageable pageable = PageRequest.of(page, size);
-        return noticeService.getAllNotices(pageable);
+        return noticeService.getAllNotices(page, size);
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -80,7 +80,7 @@ public class NoticeController {
         return noticeService.searchNotices(keyword, pageable);
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{noticeId}")
     @Operation(summary = "특정 공지사항 및 이전/다음 공지사항 조회")
     public NoticeDetailWithNavigationDto getNoticeWithNavigation(@PathVariable Long id) {
         return noticeService.getNoticeWithNavigation(id);

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -43,7 +43,7 @@ public class NoticeController {
         if (size < 1) {
             throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
         }
-        if (size > 9) {
+        if (size > 8) {
             throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
         }
 

--- a/src/main/java/com/example/humorie/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/humorie/notice/controller/NoticeController.java
@@ -49,7 +49,7 @@ public class NoticeController {
 
     @GetMapping("/{noticeId}")
     @Operation(summary = "특정 공지사항 및 이전/다음 공지사항 조회")
-    public NoticeDetailWithNavigationDto getNoticeWithNavigation(@PathVariable Long id) {
-        return noticeService.getNoticeWithNavigation(id);
+    public NoticeDetailWithNavigationDto getNoticeWithNavigation(@PathVariable Long noticeId) {
+        return noticeService.getNoticeWithNavigation(noticeId);
     }
 }

--- a/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/GetAllNoticeDto.java
@@ -11,7 +11,6 @@ import java.time.LocalTime;
 @Builder
 public class GetAllNoticeDto {
     private Long id;
-    private boolean importance;
     private String title;
     private LocalDate createdDate;
     private LocalTime createdTime;
@@ -21,7 +20,6 @@ public class GetAllNoticeDto {
     public static GetAllNoticeDto fromEntity(Notice notice) {
         return GetAllNoticeDto.builder()
                 .id(notice.getId())
-                .importance(notice.isImportance())
                 .title(notice.getTitle())
                 .createdDate(notice.getCreatedDate())
                 .createdTime(notice.getCreatedTime())

--- a/src/main/java/com/example/humorie/notice/dto/NoticeDetailDto.java
+++ b/src/main/java/com/example/humorie/notice/dto/NoticeDetailDto.java
@@ -23,7 +23,6 @@ public class NoticeDetailDto {
     private LocalTime createdTime; // 작성 시간
     private String title;          // 제목
     private String content;        // 내용
-    private boolean importance;    // 중요 여부
 
     // Notice 엔티티를 DTO로 변환하는 메서드
     public static NoticeDetailDto fromEntity(Notice notice) {
@@ -35,7 +34,6 @@ public class NoticeDetailDto {
                 .createdTime(notice.getCreatedTime())
                 .title(notice.getTitle())
                 .content(notice.getContent())
-                .importance(notice.isImportance())
                 .build();
     }
 }

--- a/src/main/java/com/example/humorie/notice/entity/Notice.java
+++ b/src/main/java/com/example/humorie/notice/entity/Notice.java
@@ -37,7 +37,5 @@ public class Notice {
     @Column(name = "view_count")
     private int viewCount;
 
-    private boolean importance;
-
     private String author;
 }

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -17,4 +17,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // 제목이나 내용에 키워드가 포함된 공지사항을 검색하는 메서드
     @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdDate DESC, n.createdTime DESC")
     Page<Notice> findByTitleContainingOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
+
+    // 공지사항 전체 조회(날짜, 시간)
+    List<Notice> findAllByOrderByCreatedDateDescCreatedTimeDesc();
 }

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -10,18 +10,11 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    // 공지사항 전체 조회(중요도, 날짜, 시간)
-    @Query("SELECT n FROM Notice n ORDER BY n.importance DESC, n.createdDate DESC, n.createdTime DESC")
-    Page<Notice> findImportantAndRecentNotices(Pageable pageable);
-
-    // 중요 공지사항 조회
-    @Query("SELECT n FROM Notice n WHERE n.importance = true ORDER BY n.createdDate DESC, n.createdTime DESC")
-    List<Notice> findImportantNotices(Pageable pageable);
+    // 공지사항 전체 조회(날짜, 시간)
+    @Query("SELECT n FROM Notice n ORDER BY n.createdDate DESC, n.createdTime DESC")
+    Page<Notice>  findAllByOrderByCreatedDateDescCreatedTimeDesc(Pageable pageable);
 
     // 제목이나 내용에 키워드가 포함된 공지사항을 검색하는 메서드
     @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdDate DESC, n.createdTime DESC")
     Page<Notice> findByTitleContainingOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
-
-    // 공지사항을 날짜와 시간 순으로 내림차순 정렬하여 전체 목록 반환
-    List<Notice> findAllByOrderByCreatedDateDescCreatedTimeDesc();
 }

--- a/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/humorie/notice/repository/NoticeRepository.java
@@ -15,7 +15,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice>  findAllByOrderByCreatedDateDescCreatedTimeDesc(Pageable pageable);
 
     // 제목이나 내용에 키워드가 포함된 공지사항을 검색하는 메서드
-    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword% ORDER BY n.createdDate DESC, n.createdTime DESC")
+    @Query("SELECT n FROM Notice n WHERE LOWER(n.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(n.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
     Page<Notice> findByTitleContainingOrContentContaining(@Param("keyword") String keyword, Pageable pageable);
 
     // 공지사항 전체 조회(날짜, 시간)

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -57,8 +57,35 @@ public class NoticeService {
 
         return NoticePageDto.from(dtoPage);
     }
-    
-    public NoticePageDto searchNotices(String keyword, Pageable pageable) {
+
+    public NoticePageDto getAllNotices(Pageable pageable) {
+        Page<Notice> noticePage = noticeRepository.findAllByOrderByCreatedDateDescCreatedTimeDesc(pageable);
+
+        Page<GetAllNoticeDto> dtoPage = noticePage.map(GetAllNoticeDto::fromEntity);
+        return NoticePageDto.from(dtoPage);
+    }
+
+    public NoticePageDto searchNotices(String keyword, int page, int size) {
+        // 페이지 번호에 대한 유효성 검사
+        if (page < 0) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_NUMBER);
+        }
+
+        // 페이지 크기에 대한 유효성 검사
+        if (size < 1) {
+            throw new ErrorException(ErrorCode.NEGATIVE_PAGE_SIZE);
+        } else if (size > 8) {
+            throw new ErrorException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 키워드가 없는 경우 전체 공지사항 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return getAllNotices(pageable);
+        }
+
         // 키워드 검색 결과 가져오기 (제목 또는 내용에서 검색)
         Page<Notice> searchResults = noticeRepository.findByTitleContainingOrContentContaining(keyword, pageable);
 

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -40,16 +40,15 @@ public class NoticeService {
         // 공지사항 조회 결과 가져오기
         Page<Notice> noticePage = noticeRepository.findAllByOrderByCreatedDateDescCreatedTimeDesc(pageable);
 
+        // 데이터가 없는 경우 빈 Page 반환
+        if (noticePage.getTotalPages() == 0) {
+            return NoticePageDto.from(Page.empty(pageable));
+        }
+
         // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
         if (pageable.getPageNumber() >= noticePage.getTotalPages()) {
             log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, noticePage.getTotalPages());
             throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
-        }
-
-        // 페이지가 비어 있을 경우 빈 리스트를 반환
-        if (noticePage.isEmpty()) {
-            // 빈 NoticePageDto 반환
-            return NoticePageDto.from(Page.empty(pageable));
         }
 
         // 엔티티를 DTO로 변환하여 NoticePageDto로 반환
@@ -88,8 +87,8 @@ public class NoticeService {
         // 키워드 검색 결과 가져오기 (제목 또는 내용에서 검색)
         Page<Notice> searchResults = noticeRepository.findByTitleContainingOrContentContaining(keyword, pageable);
 
-        // 검색 결과가 비어 있을 경우 빈 페이지를 반환
-        if (searchResults.isEmpty()) {
+        // 검색 결과가 없을 경우 빈 페이지 반환
+        if (searchResults.getTotalPages() == 0) {
             return NoticePageDto.from(Page.empty(pageable));
         }
 

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -24,13 +24,13 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
 
     public NoticePageDto getAllNotices(Pageable pageable) {
-        Page<Notice> noticePage = noticeRepository.findImportantAndRecentNotices(pageable);
+        Page<Notice> noticePage = noticeRepository.findAllByOrderByCreatedDateDescCreatedTimeDesc(pageable);
 
-        // 페이지가 비어 있는지 확인
+        // 페이지가 비어 있을 경우 빈 리스트를 반환
         if (noticePage.isEmpty()) {
-            throw new ErrorException(ErrorCode.NO_CONTENT);
+            // 빈 NoticePageDto 반환
+            return NoticePageDto.from(Page.empty(pageable));
         }
-
         // 엔티티를 DTO로 변환하여 NoticePageDto로 반환
         Page<GetAllNoticeDto> dtoPage = noticePage.map(GetAllNoticeDto::fromEntity);
         return NoticePageDto.from(dtoPage);

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -81,7 +81,16 @@ public class NoticeService {
 
         // 키워드가 없는 경우 전체 공지사항 반환
         if (keyword == null || keyword.trim().isEmpty()) {
-            return getAllNotices(pageable);
+            // 전체 공지사항 조회
+            NoticePageDto allNotices = getAllNotices(pageable);
+
+            // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
+            if (page >= allNotices.getTotalPages()) {
+                log.error("Page number {} exceeds total pages {}", page + 1, allNotices.getTotalPages());
+                throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+            }
+
+            return allNotices;
         }
 
         // 키워드 검색 결과 가져오기 (제목 또는 내용에서 검색)
@@ -90,6 +99,12 @@ public class NoticeService {
         // 검색 결과가 없을 경우 빈 페이지 반환
         if (searchResults.getTotalPages() == 0) {
             return NoticePageDto.from(Page.empty(pageable));
+        }
+
+        // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
+        if(pageable.getPageNumber() >= searchResults.getTotalPages()) {
+            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, searchResults.getTotalPages());
+            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
         }
 
         // 결과를 DTO로 변환

--- a/src/main/java/com/example/humorie/notice/service/NoticeService.java
+++ b/src/main/java/com/example/humorie/notice/service/NoticeService.java
@@ -40,6 +40,12 @@ public class NoticeService {
         // 공지사항 조회 결과 가져오기
         Page<Notice> noticePage = noticeRepository.findAllByOrderByCreatedDateDescCreatedTimeDesc(pageable);
 
+        // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
+        if (pageable.getPageNumber() >= noticePage.getTotalPages()) {
+            log.error("Page number {} exceeds total pages {}", pageable.getPageNumber() + 1, noticePage.getTotalPages());
+            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
+        }
+
         // 페이지가 비어 있을 경우 빈 리스트를 반환
         if (noticePage.isEmpty()) {
             // 빈 NoticePageDto 반환
@@ -48,13 +54,6 @@ public class NoticeService {
 
         // 엔티티를 DTO로 변환하여 NoticePageDto로 반환
         Page<GetAllNoticeDto> dtoPage = noticePage.map(GetAllNoticeDto::fromEntity);
-
-        // 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리
-        if (page >= noticePage.getTotalPages()) {
-            log.error("Page number {} exceeds total pages {}", page + 1, noticePage.getTotalPages());
-            throw new ErrorException(ErrorCode.INVALID_PAGE_NUMBER);
-        }
-
         return NoticePageDto.from(dtoPage);
     }
 


### PR DESCRIPTION


** 공지사항 전체 조회 API
- importance 필드 삭제( 데모 회의에서 중요 공지 없애기로 함 )
- createdDtate, createdTime을 기준으로 내림차순 정렬하도록 변경
- 한 페이지에 게시글이 최대 8개까지 나타나도록 변경
- 조회할 공지사항이 없는 경우 빈 페이지 반환
- 총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리

** 공지사항 검색 API
- keyword에 아무것도 입력하지 않은 경우 전체 공지사항 조회
- 키워드로 검색 시 제목 또는 내용에서 검색 결과 가져오기
- 검색 결과가 없는 경우 빈 페이지 반환
- 검색 결과 전후로  총 페이지 수보다 요청된 페이지 번호가 클 경우 예외 처리

** 특정 공지사항 및 이전/다음 공지사항 조회
- parameter 명을 id에서 noticeId로 변경
- 존재하지 않는 공지사항 식별자 입력 시 예외처리
- 특정 공지사항 클릭 시 조회수 1 증가

** ErrorCode
- NEGATIVE_PAGE_SIZE 에러 메시지 변경(0 이상이어야 -> 0보다 커야)

** DataInitializer
- 페이지네이션 작동 확인을 위해 notice 더미 데이터 2개 추가

+) 휴모리 Discord 업데이트 공지(공지사항 페이지 관련)
1. 중요 공지 제거
2. 이미지 제거(텍스트만 표기)
3. 관리자 모드 추가 ----> 작업 예정

