### PR TITLE
[Fix/#96] 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/entity/ConsultDetail.java
@@ -43,8 +43,6 @@ public class ConsultDetail {
     private String symptom;
     private String content;
 
-    private boolean deleted = false;  // 소프트 삭제 여부를 나타내는 필드
-
     public void setStatus(Boolean status) { this.status = status; }
 
     public String getContent()  { return content; }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/repository/ConsultDetailRepository.java
@@ -2,6 +2,7 @@ package com.example.humorie.consultant.consult_detail.repository;
 
 import com.example.humorie.consultant.consult_detail.entity.ConsultDetail;
 import com.example.humorie.account.entity.AccountDetail;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,17 +23,11 @@ public interface ConsultDetailRepository extends JpaRepository<ConsultDetail, Lo
     @Query("SELECT c FROM ConsultDetail c WHERE c.account = :account ORDER BY c.reservation.counselDate DESC, c.reservation.counselTime DESC")
     Page<ConsultDetail> findAllConsultDetail(@Param("account") AccountDetail account, Pageable pageable);
 
-     void deleteByAccount_Id(Long accountId);
-
-    // accountId로 ConsultDetail 조회
-    List<ConsultDetail> findByAccountId(Long accountId);
-
-    @Modifying
-    @Query("UPDATE ConsultDetail c SET c.deleted = true WHERE c.account.id = :accountId")
-    void softDeleteByAccountId(Long accountId);
-
     @Modifying
     @Query("UPDATE ConsultDetail c SET c.account = NULL WHERE c.account.id = :accountId")
     void detachAccountFromConsultDetail(@Param("accountId") Long accountId);
 
+    @Modifying
+    @Transactional
+    void deleteByAccountId(Long accountId);
 }

--- a/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
+++ b/src/main/java/com/example/humorie/consultant/consult_detail/service/ConsultDetailService.java
@@ -133,13 +133,11 @@ public class ConsultDetailService {
     }
 
     @Transactional
-    public void softDeleteConsultDetailsByAccountId(Long accountId) {
-        List<ConsultDetail> consultDetails = consultDetailRepository.findByAccountId(accountId);
-        for (ConsultDetail consultDetail : consultDetails) {
-            consultDetail.setDeleted(true); // 소프트 삭제 처리
-            consultDetailRepository.save(consultDetail);
-        }
+    public void deleteConsultDetailsByAccountId(Long accountId) {
+        // ConsultDetail에서 특정 accountId에 해당하는 모든 내역 삭제
+        consultDetailRepository.deleteByAccountId(accountId);
     }
+
     @Transactional
     public void detachAccountFromConsultDetail(Long accountId) {
         consultDetailRepository.detachAccountFromConsultDetail(accountId);

--- a/src/main/java/com/example/humorie/consultant/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/humorie/consultant/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.example.humorie.consultant.review.repository;
 
 import com.example.humorie.consultant.review.entity.Review;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,8 +17,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r WHERE r.counselor.id = :counselorId ORDER BY r.rating LIMIT 1")
     Optional<Review> findTopRatingByCounselorId(@Param(value = "counselorId") long counselorId);
-  
-    List<Review> findAllByCounselorId(Long counselorId);
 
-    void deleteByAccount_Id(Long accountId);
+    @Modifying
+    @Transactional
+    @Query("UPDATE Review r SET r.account = NULL WHERE r.account.id = :accountId")
+    void detachAccountFromReview(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
+++ b/src/main/java/com/example/humorie/consultant/review/service/ReviewService.java
@@ -125,4 +125,9 @@ public class ReviewService {
         counselor.setRating(averageRating);
     }
 
+    @Transactional
+    public void detachAccountFromReview(Long accountId) {
+        // Review 테이블에서 해당 accountId와 연결된 외래 키 참조를 제거
+        reviewRepository.detachAccountFromReview(accountId);
+    }
 }

--- a/src/main/java/com/example/humorie/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/humorie/reservation/repository/ReservationRepository.java
@@ -28,5 +28,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("UPDATE Reservation r SET r.account = NULL WHERE r.account.id = :accountId")
     void detachAccountFromReservation(@Param("accountId") Long accountId);
 
-
+    @Modifying
+    @Transactional
+    void deleteByAccountId(Long accountId);
 }

--- a/src/main/java/com/example/humorie/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/humorie/reservation/service/ReservationService.java
@@ -180,6 +180,12 @@ public class ReservationService {
     }
 
     @Transactional
+    public void deleteReservationsByAccountId(Long accountId) {
+        // Reservation에서 특정 accountId에 해당하는 모든 예약 삭제
+        reservationRepository.deleteByAccountId(accountId);
+    }
+
+    @Transactional
     public void detachAccountFromReservation(Long accountId) {
         reservationRepository.detachAccountFromReservation(accountId);
     }


### PR DESCRIPTION
** 회원 탈퇴 시 상담 후기를 제외한 다른 데이터는 삭제하도록 로직 수정 ( Soft Delete X )


1. 비밀번호 유효성 검사
2. 상담 내역 삭제 및 외래 키 참조 제거
3. 예약 삭제 처리 및 외래 키 참조 제거
4. 태그 외래 키 참조 제거
5. 리뷰 외래 키 참조 제거
6. 사용자 삭제
