### PR TITLE
[#109/refactor] 공지사항 API request body의 필드 수정

### DIFF
--- a/src/main/java/com/example/humorie/admin/dto/NoticeDto.java
+++ b/src/main/java/com/example/humorie/admin/dto/NoticeDto.java
@@ -9,13 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class NoticeDto {
-    private Long id;
     private String title;         // 제목
     private String content;       // 내용
-    private int viewCount;        // 조회수
-    private String adminName;     // 관리자 이름
-    private LocalDate createdDate; // 생성 날짜
-    private LocalTime createdTime; // 생성 시간
 
     // 엔티티 변환 메서드
     public Notice toEntity(String adminName) {


### PR DESCRIPTION

- NoticeDto에서 제목(title)과 내용(content) 필드만 남기고 다른 불필요한 필드를 제거함
- 제목과 내용 필드만으로 필요한 데이터를 수집할 수 있도록 수정

close #109 